### PR TITLE
Explicitly set CIAO_LD_LIBRARY_PATH

### DIFF
--- a/get_cat_obs_data.pl
+++ b/get_cat_obs_data.pl
@@ -49,6 +49,9 @@ our $XCORR_MAX_DIST = 5.0;
 # Set up some constants
 
 App::Env::import('CIAO');
+$ENV{CIAO_LD_LIBRARY_PATH} = sprintf("%s/lib:%s/ots/lib",
+                                     ($ENV{ASCDS_INSTALL},
+                                      $ENV{ASCDS_INSTALL}));
 
 $ENV{UPARM} = $ASTROMON_DATA;
 $| = 1;

--- a/plot_offsets.pl
+++ b/plot_offsets.pl
@@ -18,6 +18,9 @@ use PDL::NiceSlice;
 use Data::Dumper;
 use List::MoreUtils;
 use App::Env qw(CIAO);
+$ENV{CIAO_LD_LIBRARY_PATH} = sprintf("%s/lib:%s/ots/lib",
+                                     ($ENV{ASCDS_INSTALL},
+                                      $ENV{ASCDS_INSTALL}));
 use Carp;
 use Chandra::Tools::dmcoords;
 use File::Basename qw(dirname);


### PR DESCRIPTION
This is a work-around for a SKA vs CIAO CFITSIO library conflict
that arises in CIAO 4.6.
