### PR TITLE
Use slimbad hostname for local vizier fetches

### DIFF
--- a/get_cat_obs_data.pl
+++ b/get_cat_obs_data.pl
@@ -912,7 +912,7 @@ sub get_vizier {
                    '-out.add' => '_RA(J2000,J' . $self->{year} . ')',
                     '-c.rs' => $self->extr_rad * 60,
                    );
-    my $url = 'http://vizier.cfa.harvard.edu/viz-bin/asu-tsv?'
+    my $url = 'http://slimbad.cfa.harvard.edu/viz-bin/asu-tsv?'
       . join('&', map { "$_=$url_opt{$_}" } keys %url_opt);
 
     $log->message("Getting Vizier $catalog objects using '$url'");


### PR DESCRIPTION
Change the URL used in get_cat_obs_data.pl

I don't actually understand why this change is required or what slimbad really is, but this URL change seems to make the web fetch work for HEAD hosts.

This should improve these errors.  

```
Line 62: ERROR: Error accessing 'http://vizier.cfa.harvard.edu/viz-bin/asu-tsv?-c.rs=24&-out.add=_RA(J2000,J2018.10)&-c=169.77851+21.3304&-source=USNO-B1.0&-sort=_r': 500 Can't connect to vizier.cfa.harvard.edu:80 (connect: No route to host)
```

This has not been end-to-end tested within astromon; I've just confirmed that the slimbad links work from c3po-v and my machine and the vizier hostname does not.