### PR TITLE
ignore FITSFixedWarning

### DIFF
--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -4,6 +4,7 @@
 import os
 import re
 import collections
+import warnings
 # import sys
 import logging
 import argparse
@@ -21,7 +22,7 @@ from astropy.io import fits, ascii
 
 from astromon.utils import logging_call_decorator, chdir, Ciao, FlowException
 
-from astropy.wcs import WCS
+from astropy.wcs import WCS, FITSFixedWarning
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 import regions
@@ -732,7 +733,13 @@ class Observation:
         if not pileup_file.exists():
             return np.zeros(len(src))
         hdus = fits.open(pileup_file)
-        wcs = WCS(hdus[0].header)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message="'datfix' made the change 'Set DATEREF",
+                category=FITSFixedWarning
+            )
+            wcs = WCS(hdus[0].header)
         loc = SkyCoord(src['RA'] * u.deg, src['DEC'] * u.deg)
         pix = np.round(wcs.world_to_pixel(loc)).astype(int)
         return hdus[0].data[(pix[1], pix[0])]


### PR DESCRIPTION
## Description
This PR prevents this warning that occurs when creating a WCS from a fits header:
```
WARNING: FITSFixedWarning: 'datfix' made the change 'Set DATEREF to '1998-01-01' from MJDREF.
Set MJD-END to 59584.144595 from DATE-END'. [astropy.wcs.wcs]
```

## Interface impacts
None

## Testing

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
