### PR TITLE
Final tweaks before 1.0.0

### DIFF
--- a/astromon/cross_match.py
+++ b/astromon/cross_match.py
@@ -76,9 +76,8 @@ def get_vizier(pos, catalog, cat_identifier, name_cols, columns,
                 f'_RA(J2000,{pos.obstime.frac_year:8.3f})',
                 f'_DE(J2000,{pos.obstime.frac_year:8.3f})'
             ],
-            cache=False,
         )
-        vizier_result = vizier.query_region(pos, radius=radius, catalog=cat_identifier)
+        vizier_result = vizier.query_region(pos, radius=radius, catalog=cat_identifier, cache=False)
         vizier_result = [r for r in vizier_result]
     else:
         vizier_result = [

--- a/astromon/cross_match.py
+++ b/astromon/cross_match.py
@@ -75,7 +75,8 @@ def get_vizier(pos, catalog, cat_identifier, name_cols, columns,
             columns=[
                 f'_RA(J2000,{pos.obstime.frac_year:8.3f})',
                 f'_DE(J2000,{pos.obstime.frac_year:8.3f})'
-            ]
+            ],
+            cache=False,
         )
         vizier_result = vizier.query_region(pos, radius=radius, catalog=cat_identifier)
         vizier_result = [r for r in vizier_result]

--- a/astromon/db.py
+++ b/astromon/db.py
@@ -398,8 +398,10 @@ def get_cross_matches(name='astromon_21', dbfile=None, **kwargs):
         - stop
         - r_angle_grating
         - near_neighbor_dist
+        - sim_z
         - exclude_regions
         - exclude_bad_targets
+        - exclude_categories
 
         Other extra arguments can be passed. In these cases, the argument name determines on which
         column to filter. Each argument is interpreted according to the type of value passed:

--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -242,7 +242,7 @@ class Observation:
         else:
             self._obsid_info['version'] = 0.0
 
-        return(self._obsid_info)
+        return (self._obsid_info)
 
     @logging_call_decorator
     def _download_archive(self, ftypes):

--- a/astromon/scripts/get_cat_obs_data.py
+++ b/astromon/scripts/get_cat_obs_data.py
@@ -263,7 +263,7 @@ def main():
         # if args.workdir is not given, create one for the result file
         # do not pass this downstream, because it can fill the tmp directory
         tmpdir = tempfile.TemporaryDirectory()  # this variable should live until the end
-        workdir = Path(tmpdir)
+        workdir = Path(tmpdir.name)
 
     # all changes go in this file which is copied back to its final destination at the end.
     db_file = workdir / args.db_file.name

--- a/astromon/web/celmon.py
+++ b/astromon/web/celmon.py
@@ -28,55 +28,12 @@ JINJA2 = jinja2.Environment(
 )
 
 
-def good_obs(matches):
-    """
-    Discard some observations that are known to give large offsets.
-    """
-    ok = np.ones(len(matches), dtype=bool)
-    bad_targets = ['RW Aur', 'Tau Boo', '70 OPH', '16 Cyg', 'M87', 'Orion', 'HD 97950', 'HD4915']
-    bad_targets = [x.replace(' ', '').lower() for x in bad_targets]
-    for ii, target in enumerate(matches['target']):
-        target = target.replace(' ', '').lower()
-        for bad_target in bad_targets:
-            if target.startswith(bad_target):
-                ok[ii] = False
-    return ok
-
-
-def filter_xcorr(xcorr, *,
-                 snr=None, r_angle=None,
-                 start=None, stop=None,
-                 **kwargs):
-    """Filter the matched X-ray and catalog sources table.
-
-    Any additional keyword arguments are used to filter the table like:
-    - xcorr[key] == val  # scalar values
-    - np.isin(xcorr[key], val)  # list values
-
-    Returns the filtered Table.
-    """
-
-    ok = np.ones(len(xcorr), dtype=bool)
-
-    if snr is not None:
-        ok &= xcorr['snr'] >= snr
-
-    if r_angle is not None:
-        ok &= xcorr['r_angle'] <= r_angle
-
-    if start is not None:
-        ok &= xcorr['tstart'] >= CxoTime(start).secs
-
-    if stop is not None:
-        ok &= xcorr['tstart'] <= CxoTime(stop).secs
-
-    for key, val in kwargs.items():
-        if isinstance(val, list):
-            ok &= np.isin(xcorr[key], val)
-        else:
-            ok &= xcorr[key] == val
-
-    return ok
+SIM_Z = {
+    'ACIS-I': -233.587,
+    'ACIS-S': -190.143,
+    'HRC-I': 126.983,
+    'HRC-S': 250.466
+}
 
 
 def plot_offsets_history(
@@ -320,18 +277,6 @@ def binned_median(time, vals, bins_per_year=2):
     return tga
 
 
-def get_matches(snr=3):
-    all_matches = db.get_cross_matches()
-    all_matches['year'] = all_matches['time'].frac_year
-    year_bin_2 = year_bins(all_matches['time'], 2)
-    all_matches['year_bin_2'] = np.digitize(all_matches['year'], year_bin_2)
-    all_matches.meta['year_bin_2_edges'] = year_bin_2
-    ok = good_obs(all_matches)
-    ok = filter_xcorr(all_matches, snr=snr)
-    all_matches = all_matches[ok]
-    return all_matches
-
-
 def plot_cdf_2(
     all_matches,
     col,
@@ -391,20 +336,25 @@ def create_figures_mta(outdir):
 
     n_years = 5
     snr = 3
+    sim_z = 4    # max sim-z
     draw_median = True
 
     # result = {'snr': snr, 'n_years': n_years}
     result = {}
 
-    all_matches = db.get_cross_matches()
+    all_matches = db.get_cross_matches(
+        snr=snr,
+        exclude_bad_targets=True,
+        sim_z=sim_z,
+        exclude_categories=[
+            'SN, SNR, and Isolated NS', 'Solar System and Misc', 'Clusters of Galaxies'
+        ]
+    )
+
     all_matches['year'] = all_matches['time'].frac_year
     year_bin_2 = year_bins(all_matches['time'], 2)
     all_matches['year_bin_2'] = np.digitize(all_matches['year'], year_bin_2)
     all_matches.meta['year_bin_2_edges'] = year_bin_2
-
-    ok = good_obs(all_matches)
-    ok = filter_xcorr(all_matches, snr=snr)
-    all_matches = all_matches[ok]
 
     matches = all_matches[all_matches['time'] > CxoTime() - n_years * u.year]
 
@@ -493,12 +443,20 @@ def create_figures_mta(outdir):
 def create_figures_cal(outdir, snr=5, n_years=5, draw_median=True):
     outdir = Path(outdir)
 
+    sim_z = 4  # max sim-z
+
     end = CxoTime()
     start = end - n_years * u.year
-    matches = db.get_cross_matches()
-    ok = good_obs(matches)
-    ok = filter_xcorr(matches, snr=snr)
-    ok &= matches['time'] > start
+    matches = db.get_cross_matches(
+        snr=snr,
+        exclude_bad_targets=True,
+        sim_z=sim_z,
+        exclude_categories=[
+            'SN, SNR, and Isolated NS', 'Solar System and Misc', 'Clusters of Galaxies'
+        ]
+    )
+
+    ok = matches['time'] > start
     matches = matches[ok]
 
     dy_median = binned_median(

--- a/astromon/web/celmon.py
+++ b/astromon/web/celmon.py
@@ -28,14 +28,6 @@ JINJA2 = jinja2.Environment(
 )
 
 
-SIM_Z = {
-    'ACIS-I': -233.587,
-    'ACIS-S': -190.143,
-    'HRC-I': 126.983,
-    'HRC-S': 250.466
-}
-
-
 def plot_offsets_history(
         matches,
         title='Offsets History',

--- a/astromon/web/templates/celmon_cal.html
+++ b/astromon/web/templates/celmon_cal.html
@@ -123,15 +123,15 @@
 			Only observations with the following characteristics are considered:
 			<ul>
 				<li> Single-OBI observation </li>
-				<li> SIM-Z at the nominal detector value. (?) </li>
+				<li> SIM-Z at the nominal detector value. </li>
 				<li> <code>obs_mode==POINTING</code> </li>
 				<li> If it is an ACIS observation: <code> readmode==TIMED</code> and <code> dtycycle==0. </code> </li>
+				<li> Not an observation of targets known to confound the source detection. </li>
 				<li> Not in any of the following science categories: "SN, SNR, and isolated NS", "Clusters of
 					Galaxies", or "Solar System and Misc". Observations in these categories
 					are likely to confound <tt>celldetect</tt> and produce too many spurious
-					sources. (?)
+					sources.
 				</li>
-				<li> Not an observation of targets known to confound the source detection. </li>
 			</ul>
 		</p>
 	
@@ -212,21 +212,6 @@
 				<a href="http://www.astro.ku.dk/~cf/CD/docs/guide.pdf">Guide to the Tycho2 catalog
 				(PDF)</a>.
 				<a href="https://vizier.u-strasbg.fr/viz-bin/VizieR-3?-source=I/259/tyc2">VizieR</a>.
-			</li>
-			<li>
-				<a href="https://ui.adsabs.harvard.edu/abs/2003yCat.2246....0C/abstract">2MASS</a> -
-				<font class="text-danger"> Not actually used yet. </font>
-				Two micron all-sky survey: 162,213,354 million point sources from 19,600 square degrees of sky.
-				<a href="http://www.ipac.caltech.edu/2mass/releases/second/doc/sec2_2.html#pscastrprop">
-				Astrometric accuracy</a> is better than 0.2 arcsec.
-				<a href="https://vizier.u-strasbg.fr/viz-bin/VizieR?-source=II/246"> VizieR </a>.
-			</li>
-			<li>
-				<a href="https://ui.adsabs.harvard.edu/abs/2003AJ....125..984M/abstract">USNO-B1.0</a> - 
-				<font class="text-danger">Not actually used yet. </font>
-				Monet, D.G. et al. (2003), "The USNO-B Catalog", The Astronomical Journal, vol. 125, no. 2,
-				pp. 984-993.
-				<a href="https://vizier.u-strasbg.fr/viz-bin/VizieR?-source=I/284"> VizieR </a>
 			</li>
 		</ul>
 

--- a/astromon/web/templates/celmon_cal.html
+++ b/astromon/web/templates/celmon_cal.html
@@ -139,7 +139,7 @@
 			During the source detection process, the detected sources fulfill the following requirements:
 			<ul>
 				<li> <code> SNR > {{ data.cal.snr }} </code> </li>
-				<li> For grating observations, sources must be within 0.4 arcmin from the optical axis. (?) </li>
+				<li> For grating observations, sources must be within 0.4 arcmin from the optical axis. </li>
 				<li> For imaging observations, sources must be within 3 arcmin from the optical axis. </li>
 			</ul>
 		</p>

--- a/astromon/web/templates/celmon_mta.html
+++ b/astromon/web/templates/celmon_mta.html
@@ -140,15 +140,15 @@
 			Only observations with the following characteristics are considered:
 			<ul>
 				<li> Single-OBI observation </li>
-				<li> SIM-Z at the nominal detector value. (?) </li>
+				<li> SIM-Z at the nominal detector value. </li>
 				<li> <code>obs_mode==POINTING</code> </li>
 				<li> If it is an ACIS observation: <code> readmode==TIMED</code> and <code> dtycycle==0. </code> </li>
+				<li> Not an observation of targets known to confound the source detection. </li>
 				<li> Not in any of the following science categories: "SN, SNR, and isolated NS", "Clusters of
 					Galaxies", or "Solar System and Misc". Observations in these categories
 					are likely to confound <tt>celldetect</tt> and produce too many spurious
-					sources. (?)
+					sources.
 				</li>
-				<li> Not an observation of targets known to confound the source detection. </li>
 			</ul>
 		</p>
 	
@@ -229,21 +229,6 @@
 				<a href="http://www.astro.ku.dk/~cf/CD/docs/guide.pdf">Guide to the Tycho2 catalog
 				(PDF)</a>.
 				<a href="https://vizier.u-strasbg.fr/viz-bin/VizieR-3?-source=I/259/tyc2">VizieR</a>.
-			</li>
-			<li>
-				<a href="https://ui.adsabs.harvard.edu/abs/2003yCat.2246....0C/abstract">2MASS</a> -
-				<font class="text-danger"> Not actually used yet. </font>
-				Two micron all-sky survey: 162,213,354 million point sources from 19,600 square degrees of sky.
-				<a href="http://www.ipac.caltech.edu/2mass/releases/second/doc/sec2_2.html#pscastrprop">
-				Astrometric accuracy</a> is better than 0.2 arcsec.
-				<a href="https://vizier.u-strasbg.fr/viz-bin/VizieR?-source=II/246"> VizieR </a>.
-			</li>
-			<li>
-				<a href="https://ui.adsabs.harvard.edu/abs/2003AJ....125..984M/abstract">USNO-B1.0</a> - 
-				<font class="text-danger">Not actually used yet. </font>
-				Monet, D.G. et al. (2003), "The USNO-B Catalog", The Astronomical Journal, vol. 125, no. 2,
-				pp. 984-993.
-				<a href="https://vizier.u-strasbg.fr/viz-bin/VizieR?-source=I/284"> VizieR </a>
 			</li>
 		</ul>
 

--- a/astromon/web/templates/celmon_mta.html
+++ b/astromon/web/templates/celmon_mta.html
@@ -156,7 +156,7 @@
 			During the source detection process, the detected sources fulfill the following requirements:
 			<ul>
 				<li> <code> SNR > {{ data.cal.snr }} </code> </li>
-				<li> For grating observations, sources must be within 0.4 arcmin from the optical axis. (?) </li>
+				<li> For grating observations, sources must be within 0.4 arcmin from the optical axis. </li>
 				<li> For imaging observations, sources must be within 3 arcmin from the optical axis. </li>
 			</ul>
 		</p>

--- a/astromon/web/templates/summary.html
+++ b/astromon/web/templates/summary.html
@@ -1,8 +1,8 @@
 			<p> The absolute positional accuracy of source coordinates in Chandra observations is estimated
 				measuring the distances between Chandra X-ray source
 				positions and corresponding optical/radio counterpart positions
-				from <a href="#catalogs"> accurate catalogs </a>. This includes observations
-				between {{ data.cal.start_date }} and {{ data.cal.end_date }}.
+				from <a href="#catalogs"> accurate catalogs </a>. The figures in this page are based
+				on observations between {{ data.cal.start_date }} and {{ data.cal.end_date }}.
 			</p>
 
 			<p>

--- a/task_schedules/task_schedule_update.cfg
+++ b/task_schedules/task_schedule_update.cfg
@@ -22,7 +22,7 @@ master_log   astromon_update.log             # Composite master log (created in 
 # Processing errors *within* the jobs are caught with watch_cron_logs
 
 alert        javier.gonzalez@cfa.harvard.edu
-notify       javier.gonzalez@cfa.harvard.edu
+notify       aca@cfa.harvard.edu
 
  notify_msg <<NOTIFY
   Astromon ran
@@ -34,11 +34,10 @@ NOTIFY
   check_cron * * * * *
   exec 1: cp $ENV{SKA}/data/astromon/astromon.h5 $ENV{SKA}/data/astromon/tmp
   exec 1: astromon-cross-match --archive-dir $ENV{SKA}/data/astromon/tmp --db-file $ENV{SKA}/data/astromon/tmp/astromon.h5
-  exec 1: chown -R :aspect $ENV{SKA}/data/astromon/tmp/obs*
-  exec 1: cp -fr $ENV{SKA}/data/astromon/tmp/obs* $ENV{SKA}/data/astromon/archive
-  exec 1: rm -fr $ENV{SKA}/data/astromon/tmp/obs*
+  exec 1: chown -R :aspect-kadi $ENV{SKA}/data/astromon/tmp/obs*
+  exec 1: rsync -a --remove-source-files $ENV{SKA}/data/astromon/tmp/obs* $ENV{SKA}/data/astromon/archive
   exec 1: mv $ENV{SKA}/data/astromon/tmp/astromon.h5 $ENV{SKA}/data/astromon/
-  exec 1: astromon-web-pages --out $ENV{SKA}/data/astromon/web/mta
+  exec 1: astromon-web-pages --out $ENV{SKA}/data/astromon/web
   <check>
     <error>
       #    File                  Expression

--- a/task_schedules/task_schedule_update.cfg
+++ b/task_schedules/task_schedule_update.cfg
@@ -43,7 +43,6 @@ NOTIFY
       #    File                  Expression
       #  ----------             ---------------------------
       astromon_update.log       error
-      astromon_update.log       warning
       astromon_update.log       fail
       astromon_update.log       fatal
     </error>


### PR DESCRIPTION
## Description

This PR is to iron out any small issues left before the 1.0.0 release. After these changes, the information in the celmon web pages should correspond to what is actually done in the code.

This PR introduces two small changes in `celmon.py` that do not change results much:
- exclude observations with `SIM-Z offset > 4 mm`. This is consistent with legacy astromon, and I was not doing it.
- exclude observations with categories in a given list. I think this is actually not necessary, but it is consistent with legacy astromon.

There is a weekly astromon processing that is running weekly for testing and these changes are included there as I make alpha releases from this branch.

## Interface impacts
This PR includes edits to the web pages:
- [cal](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/celmon/cal)
- [mta](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/celmon/mta)

## Testing

### Unit tests
- [x] Mac

### Functional tests

I ran the weekly processing and the summary of the resulting log file seems ok to me (the cache error is gone):
```
WARNING: 139 observations , 84 skipped.
WARNING: 39 skipped: No x-ray sources found (23907, 24328, 25229, 23841, 25235, 24118, 23904, 24117, 23902, 23905, 24098, 26450, 23903, 24119, 23424, 24070, 25721, 23899, 24101, 25623, 24040, 25110, 24099, 24115, 24218, 24959, 24071, 24221, 24100, 23908, 24114, 24220, 23767, 25359, 23900, 26449, 24069, 23901, 26451)
WARNING: 45 skipped: does not fulfill observation requirements (45378, 45400, 45390, 45372, 45375, 45381, 45386, 45361, 45387, 45370, 45358, 45393, 45389, 45391, 45395, 45367, 45362, 45392, 45396, 45374, 45384, 45368, 45369, 45380, 45397, 45364, 45366, 45371, 45376, 45365, 22676, 45373, 45360, 45382, 45363, 45399, 45398, 45383, 45388, 45379, 45385, 45377, 45359, 45394, 26477)
```
