### PR TITLE
Improvements to processing downstream

### DIFF
--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -187,7 +187,7 @@ class Observation:
                 logger.warning(f"CIAO could not be initialized: {e}")
 
     def __del__(self):
-        if self._clear:
+        if hasattr(self, "_clear") and self._clear:
             logger.info(f"Clearing {self.workdir}")
             shutil.rmtree(self.workdir, ignore_errors=True)
 

--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -3,10 +3,9 @@
 
 import argparse
 import collections
-import json
+import functools
 
 # import sys
-import logging
 import os
 import re
 import shutil
@@ -20,19 +19,24 @@ import chardet
 import numpy as np
 import regions
 import requests
+import Ska.arc5gl
 from astropy import table
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import ascii, fits
 from astropy.wcs import WCS, FITSFixedWarning
+from chandra_aca.transform import radec_to_yagzag
+from Quaternion import Quat
+from ska_helpers.logging import basic_logger
 
-from astromon.utils import Ciao, FlowException, chdir, logging_call_decorator
+from astromon.stored_result import Storage, stored_result
+from astromon.task import TASKS, ReturnCode, ReturnValue, dependencies, run_tasks, task
+from astromon.utils import Ciao, chdir, logging_call_decorator
 
 __all__ = ["Observation"]
 
 
-logger = logging.getLogger("astromon")
-
+logger = basic_logger(__name__, level="WARNING")
 
 _multi_obi_obsids = [
     82,
@@ -94,16 +98,17 @@ Mapping between observation category names and numerical values.
 """
 
 
-class Skipped(FlowException):
-    """
-    Exception class used to abort and silently skip processing an observation.
-    """
-
-
-class SkippedWithWarning(FlowException):
-    """
-    Exception class used to abort, issue a warning, and skip processing an observation.
-    """
+@functools.cache
+def ciao_fails(ciao_prefix, workdir):
+    try:
+        Ciao(
+            prefix=ciao_prefix,
+            workdir=workdir,
+            logger="astromon",
+        )
+        return ""
+    except Exception as e:
+        return f"CIAO could not be initialized: {e}"
 
 
 class Observation:
@@ -143,7 +148,8 @@ class Observation:
         archive_regex=None,
         use_ciao=True,
     ):
-        use_ciao = use_ciao or ciao_prefix
+        self.use_ciao = use_ciao or ciao_prefix
+        self.ciao_prefix = ciao_prefix
         self._clear = workdir is None
         self.tmp = tempfile.TemporaryDirectory() if workdir is None else None
         self.obsid = str(obsid)
@@ -153,38 +159,82 @@ class Observation:
             / subdir
             / self.obsid
         )
+        # checking if the workdir exists before creating is faster than passing the
+        # exist_ok=True argument to mkdir, and there are thousands of observations
+        # so this is a significant speedup
+        if not self.workdir.exists():
+            self.workdir.mkdir(parents=True)
         self.archive_dir = (
             (Path(archive_dir).expanduser() / subdir / self.obsid)
             if archive_dir
             else None
         )
+        self.storage = Storage(
+            workdir=self.workdir,
+            archive_dir=self.archive_dir,
+        )
+
+        self.cache_dir = self.workdir / "cache"
+
         if archive_regex is None:
             self.archive_regex = [
                 "*.par.gz",
-                "seq_summary.json",
-                # '*evt2_filtered.fits.gz',
+                "cache",
                 "*_wide_flux.img",
                 "*_broad_flux.img",
                 "*_acis_streaks.txt",
                 "*.src",
-                "calalign.json",
             ]
         else:
             self.archive_regex = archive_regex
         self._source = source
         logger.info(f"{self} starting. Context: {self.workdir}")
         self._rebin = False
-        self._is_hrc = self.get_obspar()["instrume"].lower() == "hrc"
-        self.ciao = None
-        if use_ciao:
+        self.ciao_ = None
+        # ciao is initialized only if needed, but we make this check at the very beginning
+        # so the user gets a warning at the top if calling CIAO will likely fail
+        if self.use_ciao and (msg := ciao_fails(ciao_prefix, workdir)):
+            self.use_ciao = False
+            logger.warning(msg)
+
+    is_multi_obi = property(
+        lambda self: int(self.get_obspar()["obsid"]) in _multi_obi_obsids
+    )
+
+    is_hrc = property(lambda self: self.get_obspar()["instrume"].lower() == "hrc")
+
+    is_acis = property(lambda self: self.get_obspar()["instrume"].lower() == "acis")
+
+    def create_archive_symlinks(self):
+        """
+        Create symlinks from working directory to the archive.
+
+        Normally this should not be needed, but it might be convenient so one works only in the
+        working directory. It is a bit slow (about 0.07 seconds, which translates to 5 minutes when
+        creating instances for 5000 observations).
+        """
+        if self.archive_dir is not None:
+            for file in self.archive_dir.glob("**/*"):
+                if not file.is_dir():
+                    dest = self.workdir / file.relative_to(self.archive_dir)
+                    if not dest.exists():
+                        dest.parent.mkdir(parents=True, exist_ok=True)
+                        os.symlink(file, dest)
+
+    def get_ciao(self):
+        if self.use_ciao and self.ciao_ is None:
             try:
-                self.ciao = Ciao(
-                    prefix=ciao_prefix,
+                self.ciao_ = Ciao(
+                    prefix=self.ciao_prefix,
                     workdir=self.workdir / "param",
                     logger="astromon",
                 )
             except Exception as e:
+                self.use_ciao = False
                 logger.warning(f"CIAO could not be initialized: {e}")
+        return self.ciao_
+
+    ciao = property(get_ciao)
 
     def __del__(self):
         if hasattr(self, "_clear") and self._clear:
@@ -205,6 +255,33 @@ class Observation:
         obsid_info.update(self._get_sequence_summary())
         return obsid_info
 
+    def file_glob(self, pattern):
+        files = {}
+        if self.archive_dir is not None:
+            files.update(
+                {
+                    pth.relative_to(self.archive_dir): pth
+                    for pth in self.archive_dir.glob(pattern)
+                }
+            )
+        files.update(
+            {pth.relative_to(self.workdir): pth for pth in self.workdir.glob(pattern)}
+        )
+        return list(files.values())
+
+    def file_path(self, path):
+        if Path(path).is_absolute():
+            raise Exception(
+                f"argument to Observation.file_path must be a relative path ({path})"
+            )
+        wp = self.workdir / path
+        if self.archive_dir is not None:
+            ap = self.archive_dir / path
+            if not wp.exists() and ap.exists():
+                return ap
+        return wp
+
+    @stored_result("seq_summary", fmt="json", subdir="cache")
     def _get_sequence_summary(self):
         def parse_name_value(child):
             names = ["Title", "PI", "Observer", "Subject Category", "Cycle"]
@@ -215,10 +292,6 @@ class Observation:
                     return {_name: _value}
             return {}
 
-        filename = (self.workdir) / "seq_summary.json"
-        if filename.exists():
-            with open(filename) as fh:
-                return json.load(fh)
         obspar = self.get_obspar()
         url = "https://icxc.harvard.edu/cgi-bin/mp/target.cgi?{seq_num}"
         r = requests.get(url.format(**obspar))
@@ -235,26 +308,29 @@ class Observation:
             info["Subject Category"] = "NO MATCH"
         info["category_id"] = CATEGORY_ID_MAP[info["Subject Category"].lower()]
 
-        with open(filename, "w") as fh:
-            json.dump(info, fh)
-
         return info
 
+    @stored_result("obspar", fmt="json", subdir="cache")
     def get_obspar(self):
         """
         Get the contents of the obs0 file as a dictionary.
         """
-        (self.workdir).mkdir(exist_ok=True, parents=True)
-        obspar_file = list((self.workdir).glob("*obs0*"))
+        obspar_file = self.file_glob("*obs0*")
         if not obspar_file:
             logger.debug(f"{self} No obspar file for OBSID {self.obsid}. Downloading")
             self.download(["obspar"])
-        obspar_file = list((self.workdir).glob("*obs0*"))
+        obspar_file = self.file_glob("*obs0*")
         if len(obspar_file) == 0:
             raise Exception(f"{self} No obspar file for OBSID {self.obsid}.")
         obspar_file = str(obspar_file[0])
         t = ascii.read(obspar_file)
-        self._obsid_info = {r[0]: r[3] for r in t}
+
+        types = {
+            "r": float,
+            "s": str,
+            "i": int,
+        }
+        self._obsid_info = {row["col1"]: types[row["col2"]](row["col4"]) for row in t}
         self._obsid_info["instrument"] = self._obsid_info["instrume"].lower()
         self._obsid_info["obsid"] = int(self.obsid)
         self._obsid_info["target"] = self._obsid_info["object"]
@@ -262,8 +338,6 @@ class Observation:
         self._obsid_info["dec"] = float(self._obsid_info["dec_nom"])
         self._obsid_info["ra"] = float(self._obsid_info["ra_nom"])
         self._obsid_info["roll"] = float(self._obsid_info["roll_nom"])
-
-        import re
 
         m = re.match(r"(\d+).(\d+).(\d+)", self._obsid_info["ascdsver"])
         if m:
@@ -289,7 +363,7 @@ class Observation:
             logger.debug(f"{self} {secondary} exists, skipping download")
             return
 
-        repro = self.workdir / "repro"
+        repro = self.file_path("repro")
         if repro.exists():
             logger.debug(f"{self} {repro} exists, skipping download")
             return
@@ -319,7 +393,6 @@ class Observation:
         """
         Download data from chandra public archive
         """
-        import Ska.arc5gl
 
         for ftype in ftypes:
             if ftype == "obspar":
@@ -332,14 +405,19 @@ class Observation:
                     )
                     continue
                 src, dest = locs[ftype]
+            if src[:4] == "none":
+                # if instrument is NONE, there will be no files, no point in trying
+                continue
             logger.info(f"{self}   {ftype=}")
-            dest_files = list((self.workdir / dest).glob(f"*{ftype}*"))
+            dest_files = self.file_glob(f"{dest}/*{ftype}*")
             if dest_files:
                 logger.info(f"{self}     skipping download of *{ftype}*")
                 continue
             logger.info(f"{self}     {src} -> {dest}")
-            (self.workdir / dest).mkdir(exist_ok=True, parents=True)
-            with chdir(self.workdir / dest):
+            dest = self.workdir / dest
+            if not dest.exists():
+                dest.mkdir(exist_ok=True, parents=True)
+            with chdir(dest):
                 arc5gl = Ska.arc5gl.Arc5gl()
                 arc5gl.sendline(f"obsid={self.obsid}")
                 arc5gl.sendline(f"get {src}")
@@ -379,12 +457,10 @@ class Observation:
             Optional. If not given, self.archive_dir is used.
             Long-term location where to store files.
         """
-        if not regex:
-            regex = self.archive_regex
-        if destination is None:
-            destination = self.archive_dir
-        else:
-            destination = Path(destination) / self.obsid
+        regex = regex if regex else self.archive_regex
+        destination = (
+            Path(destination) / self.obsid if destination else self.archive_dir
+        )
         if destination is None:
             raise Exception("archive destination was not specified")
         logger.debug(f"{self} Archiving to {destination}:")
@@ -392,19 +468,36 @@ class Observation:
             for src in self.workdir.rglob(f"**/{pattern}"):
                 logger.debug(f"{self}   - {src}")
                 dest = destination / src.relative_to(self.workdir)
-                dest.parent.mkdir(exist_ok=True, parents=True)
+                if not dest.parent.exists():
+                    dest.parent.mkdir(exist_ok=True, parents=True)
                 if src.is_dir():
-                    shutil.copytree(src, dest, dirs_exist_ok=True)
+                    if not dest.exists():
+                        dest.mkdir(exist_ok=True, parents=True)
+                    for src_2 in src.glob("**/*"):
+                        if src_2.is_dir():
+                            # Only files are copied. Parent directories are created automatically.
+                            # empty directories are not copied
+                            continue
+                        dest_2 = destination / src_2.relative_to(self.workdir)
+                        if not dest_2.parent.exists():
+                            dest_2.parent.mkdir(exist_ok=True, parents=True)
+                        try:
+                            shutil.copy(src_2, dest_2)
+                        except shutil.SameFileError:
+                            # links to the same file are not copied
+                            pass
                 else:
-                    shutil.copy(src, dest)
+                    try:
+                        shutil.copy(src, dest)
+                    except shutil.SameFileError:
+                        pass
 
     @logging_call_decorator
     def repro(self):
         """
         Reprocess data.
         """
-        images = self.workdir / "images"
-        if images.exists():
+        if self.file_path("images").exists():
             # Skip repro, already done
             return
 
@@ -418,239 +511,64 @@ class Observation:
         )
 
     @logging_call_decorator
-    def make_images(self, evt=None):
+    def make_images(self):
         """
         Create image. Also creates the exposure map and psfmap.
         """
-
-        if evt is None:
-            evtfiles = list((self.workdir / "primary").glob("*_evt2_filtered.fits*"))
-            if len(evtfiles) != 1:
-                raise Exception(f"Expected 1 evt file, there are {len(evtfiles)}")
-            evt = evtfiles[0]
-
-        process = subprocess.Popen(
-            ["dmlist", f"{evt}[2]", "count"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            env=self.ciao.env,
-        )
-        output, _ = process.communicate()
-        n_events = int(output)
-        if n_events <= 0:
-            raise SkippedWithWarning(
-                f"No events in {evt.absolute().relative_to(self.workdir.absolute())}"
-            )
-
-        # are there more? is it always level1?
-        fov_files = list((self.workdir / "primary").glob("*_fov1.fits*"))
-        if len(fov_files) != 1:
-            raise Exception(f"Expected 1 FOV file, there are {len(fov_files)}")
-        fov_file = fov_files[0]
-
-        outdir = self.workdir / "images"
-        if outdir.exists():
-            logger.info(f"{self}   directory {outdir} exists, skipping")
-            return
-
-        outdir.mkdir(exist_ok=True)
-
-        band = "wide" if self._is_hrc is True else "broad"
-        self.ciao(
-            "fluximage",
-            infile=evt,
-            outroot=outdir / self.obsid,
-            bands=band,
-            binsize=(4 if self._rebin else 1) if self._is_hrc is True else 1,
-            psfecf=0.9,
-            background="none",
-            logging_tag=str(self),
-        )
-        if self.get_obspar()["instrume"] == "ACIS":
-            pileup_file = outdir / (self.obsid + "_pileup.img")
-            pileup_max_file = outdir / (self.obsid + "_pileup_max.img")
-            self.ciao(
-                "pileup_map",
-                infile=outdir / (self.obsid + "_" + band + "_thresh.img"),
-                outfile=pileup_file,
-                clobber="yes",
-                logging_tag=str(self),
-            )
-            self.ciao(
-                "dmimgfilt",
-                infile=pileup_file,
-                outfile=pileup_max_file,
-                fun="max",
-                mask="circle(0,0,3)",
-                clobber="yes",
-                logging_tag=str(self),
-            )
-            try:
-                self.ciao(
-                    "acis_streak_map",
-                    infile=str(evt).replace("_filtered", ""),
-                    fovfile=fov_file,
-                    bkgroot=outdir / (self.obsid + "_acis_streaks_bkg.fits"),
-                    regfile=outdir / (self.obsid + "_acis_streaks.txt"),
-                    msigma="4",
-                    clobber="yes",
-                    logging_tag=str(self),
-                )
-            except Exception:
-                logger.warning(f"{self}   acis_streak_map failed")
+        return make_images.run(self, run_dependencies=True)
 
     @logging_call_decorator
-    def run_wavdetect(self, edition, skip_exist=False, scales="1.4 2 4 8 16 32"):
+    def run_wavdetect(self):
         """
         Run wavdetect.
         """
-
-        imgdir = self.workdir / "images"
-        detdir = self.workdir / "sources"
-        detdir.mkdir(parents=True, exist_ok=True)
-
-        band = "wide" if self._is_hrc else "broad"
-        root = f"{self.obsid}_{edition}"
-
-        outfile = detdir / (root + ".src")
-        if outfile.exists() and skip_exist:
-            return
-
-        scales = scales.split()
-        # if wavdetect fails, it tries again removing the largest two scales
-        for _ in range(2):
-            try:
-                self.ciao(
-                    "wavdetect",
-                    infile=imgdir / (self.obsid + "_" + band + "_thresh.img"),
-                    expfile=imgdir
-                    / (self.obsid + "_" + band + "_thresh.expmap"),  # exposure map
-                    psffile=imgdir
-                    / (self.obsid + "_" + band + "_thresh.psfmap"),  # PSF
-                    outfile=outfile,
-                    scellfile=detdir / (root + ".cell"),
-                    imagefile=detdir / (root + ".img"),
-                    defnbkgfile=detdir / (root + ".nbkg"),
-                    scales=" ".join(scales),
-                    clobber="yes",
-                    logging_tag=str(self),
-                )
-            except Exception:
-                scales = scales[:-1]
-                if len(scales) < 3:
-                    raise
+        return wavdetect.run(self, run_dependencies=True)
 
     @logging_call_decorator
-    def run_celldetect(self, snr=3):
+    def run_celldetect(self):
         """
         Run celldetect.
         """
-        # Find sources in the small field
-        imgdir = self.workdir / "images"
-        band = "wide" if self._is_hrc else "broad"
-        self.ciao(
-            "celldetect",
-            imgdir / f"{self.obsid}_{band}_thresh.img",
-            self.workdir / "sources" / f"{self.obsid}_celldetect.src",
-            psffile=imgdir
-            / f"{self.obsid}_{band}_thresh.psfmap",  # either this or set fixedcell=
-            thresh=snr,
-            maxlogicalwindow=2048,
-            clobber="yes",
-            logging_tag=str(self),
-        )
+        return celldetect.run(self, run_dependencies=True)
 
     @logging_call_decorator
-    def filter_events(self, radius=180, psfratio=1):  # radius in arcsec
+    def filter_events(self):
         """
         Filter x-ray events outside a radius around the optical axis.
         """
-        # I'm using a fixed pixel size of 0.5 arcsec, but this might need fixing
-        pixel = 1 if self._is_hrc else 0.5
-        if self._rebin and self._is_hrc:
-            pixel *= 2
-        try:
-            evt = list((self.workdir / "primary").glob("*evt2.fits*"))[0]
-        except Exception:
-            raise SkippedWithWarning("evt2 file not found") from None
-
-        evt2 = str(evt).replace("evt2", "evt2_filtered")
-
-        if Path(evt2).exists():
-            logger.info(f"{self}   file {evt2} exists, skipping")
-            return
-
-        self.ciao("dmkeypar", evt, "RA_PNT", logging_tag=str(self))
-        ra = self.ciao.pget("dmkeypar", logging_tag=str(self))
-        self.ciao("dmkeypar", evt, "DEC_PNT", logging_tag=str(self))
-        dec = self.ciao.pget("dmkeypar", logging_tag=str(self))
-
-        if not ra:
-            raise Exception("RA is not set")
-        if not dec:
-            raise Exception("DEC is not set")
-        self.ciao(
-            "dmcoords",
-            evt,
-            op="cel",
-            celfmt="deg",
-            ra=ra,
-            dec=dec,
-            logging_tag=str(self),
-        )
-        x = self.ciao.pget("dmcoords", "x", logging_tag=str(self))
-        y = self.ciao.pget("dmcoords", "y", logging_tag=str(self))
-        logger.info(f"{self} filtering circle({x},{y},{radius / pixel}).")
-        self.ciao(
-            "dmcopy",
-            f"{evt}[(x,y)=circle({x},{y},{radius / pixel})]",
-            evt2,
-            logging_tag=str(self),
-        )
-
-        return evt2
+        return filter_events.run(self, run_dependencies=True)
 
     @logging_call_decorator
-    def filter_sources(self, radius=180, psfratio=1):  # radius in arcsec
+    def filter_sources(self):
         """
         Filter detected sources outside a radius around the optical axis.
         """
-        # I'm using a fixed pixel size of 0.5 arcsec, but this might need fixing
-        pixel = 1 if self._is_hrc else 0.5
-        if self._rebin and self._is_hrc:
-            pixel *= 2
-        try:
-            evt = list((self.workdir / "primary").glob("*evt2.fits*"))[0]
-        except Exception:
-            raise Exception("evt2 file not found   ") from None
+        return filter_sources.run(self, run_dependencies=True)
 
-        src = self.workdir / "sources" / f"{self.obsid}_baseline.src"
-        if not src.exists():
-            raise Exception("src file not found   ")
-        src2 = str(src).replace("baseline", "filtered")
-
-        self.ciao("dmkeypar", evt, "RA_PNT", logging_tag=str(self))
-        ra = self.ciao.pget("dmkeypar", logging_tag=str(self))
-        self.ciao("dmkeypar", evt, "DEC_PNT", logging_tag=str(self))
-        dec = self.ciao.pget("dmkeypar", logging_tag=str(self))
-
-        self.ciao("dmcoords", evt, op="cel", celfmt="deg", ra=ra, dec=dec)
-        x = self.ciao.pget("dmcoords", "x", logging_tag=str(self))
-        y = self.ciao.pget("dmcoords", "y", logging_tag=str(self))
-        filters = [f"psfratio=:{psfratio}", f"(x,y)=circle({x},{y},{radius / pixel})"]
-        filters = ",".join(filters)
-        self.ciao("dmcopy", f"{src}[{filters}]", src2, logging_tag=str(self))
-
-        return src2
-
+    @dependencies(
+        optional_files={
+            "sources": "sources/{obsid}_baseline.src",
+            "images": "images/{obsid}_{band}_flux.img",
+        },
+        variables={
+            "band": lambda obs: "wide" if obs.is_hrc else "broad",
+        },
+    )
     @logging_call_decorator
     def calculate_centroids(self):
         """
         Re-compute centroids.
         """
-        src_hdus = fits.open(self.workdir / "sources" / f"{self.obsid}_baseline.src")
-        band = "wide" if self._is_hrc else "broad"
-        img = self.workdir / "images" / f"{self.obsid}_{band}_flux.img"
+        dtype = [("x", float), ("y", float)]
+        if not (
+            wavdetect.get_result(self).return_code == ReturnCode.OK
+            and make_images.get_result(self).return_code == ReturnCode.OK
+        ):
+            return np.array([], dtype=dtype)
+
+        src_hdus = fits.open(self.file_path(f"sources/{self.obsid}_baseline.src"))
+        band = "wide" if self.is_hrc else "broad"
+        img = self.file_path(f"images/{self.obsid}_{band}_flux.img")
 
         if not img.exists():
             raise Exception(f"Image file not found {img}")
@@ -672,22 +590,25 @@ class Observation:
                 )
             ).astype(float)
             result.append([x, y])
-        return np.array(result, dtype=[("x", float), ("y", float)])
+        return np.array(result, dtype=dtype)
 
-    @logging_call_decorator
-    def process(self):
+    @property
+    def is_selected(self):
         """
-        Main routine to process a single obsid with "standard" steps.
+        Check if the observation fulfills the requirements for astromon processing.
 
         This function skips:
             - observations with obs_mode other than "POINTING".
             - ACIS observations with readmode other than "TIMED" and dtycycle different than 0.
-        """
 
-        self.download()
+        Returns
+        -------
+        bool
+            True if the observation is suitable for astromon processing, False otherwise.
+        """
         obsid_info = self.get_info()
 
-        ok = (
+        return (
             int(obsid_info["obsid"]) not in _multi_obi_obsids
             # and obsid_info['category_id'] not in [110]
             and obsid_info["obs_mode"] == "POINTING"
@@ -701,34 +622,81 @@ class Observation:
                 )
             )
         )
-        if not ok:
-            raise Skipped("does not fulfill observation requirements")
-
-        # Repro
-        # repro(self.obsid)
-
-        # Analysis
-        self.filter_events()
-        self.make_images()
-        self.run_wavdetect("baseline", skip_exist=True)
-        self.run_celldetect()
 
     @logging_call_decorator
-    def get_sources(self, version="celldetect"):
+    def process(self):
+        """
+        Main routine to process a single obsid with "standard" steps.
+        """
+
+        if not self.is_selected:
+            return ReturnValue(
+                return_code=ReturnCode.SKIP,
+                msg="observation does not fulfill requirements",
+            )
+
+        band = "wide" if self.is_hrc else "broad"
+        rv = run_tasks(
+            self,
+            requested_files=[
+                f"images/{self.obsid}_{band}_flux.img",
+                f"sources/{self.obsid}_celldetect.src",
+                f"sources/{self.obsid}_baseline.src",
+            ],
+        )
+        if any(v.return_code.value >= ReturnCode.ERROR.value for v in rv.values()):
+            return [
+                v for v in rv.values() if v.return_code.value >= ReturnCode.ERROR.value
+            ][0]
+        elif any(v.return_code.value >= ReturnCode.SKIP.value for v in rv.values()):
+            return [
+                v for v in rv.values() if v.return_code.value >= ReturnCode.SKIP.value
+            ][0]
+        else:
+            return ReturnValue(return_code=ReturnCode.OK)
+
+    @stored_result("sources", fmt="table", subdir="cache")
+    @dependencies(
+        optional_files={
+            "sources": "sources/{obsid}_{version}.src",
+            "pileup": "images/{obsid}_pileup_smeared.img",
+            "acis_streaks": "images/{obsid}_acis_streaks.txt",
+        },
+    )
+    @logging_call_decorator
+    def get_sources(self, *, version="celldetect"):
         """
         Returns a table of sources formatted for the astromon_xray_source SQL table
         """
-        from chandra_aca.transform import radec_to_yagzag
-        from Quaternion import Quat
+        # default dtype to be used when returning an empty list
+        dtype = [
+            ("obsid", ">i8"),
+            ("id", ">i4"),
+            ("ra", ">f8"),
+            ("dec", ">f8"),
+            ("net_counts", ">f4"),
+            ("y_angle", ">f8"),
+            ("z_angle", ">f8"),
+            ("r_angle", ">f8"),
+            ("snr", ">f4"),
+            ("near_neighbor_dist", ">f8"),
+            ("psfratio", ">f4"),
+            ("pileup", ">f4"),
+            ("acis_streak", "?"),
+            ("caldb_version", "<U6"),
+        ]
+
+        if TASKS.tasks[version].get_cache(self).return_code != ReturnCode.OK:
+            return table.Table(dtype=dtype)
 
         obspar = self.get_obspar()
         q = Quat(equatorial=(obspar["ra_pnt"], obspar["dec_pnt"], obspar["roll_pnt"]))
 
-        hdu_list = fits.open(self.workdir / "sources" / f"{self.obsid}_{version}.src")
+        hdu_list = fits.open(self.file_path(f"sources/{self.obsid}_{version}.src"))
         sources = table.Table(hdu_list[1].data)
 
         if len(sources) == 0:
-            raise SkippedWithWarning("No x-ray sources found")
+            return table.Table(dtype=dtype)
 
         sources["pileup"] = self._pileup_value(sources)
         sources["acis_streak"] = self._on_acis_streak(sources)
@@ -789,7 +757,7 @@ class Observation:
         return sources[cols]
 
     def _pileup_value(self, src):
-        pileup_file = self.workdir / "images" / f"{self.obsid}_pileup_max.img"
+        pileup_file = self.file_path(f"images/{self.obsid}_pileup_smeared.img")
         if not pileup_file.exists():
             return np.zeros(len(src))
         hdus = fits.open(pileup_file)
@@ -805,7 +773,7 @@ class Observation:
         return hdus[0].data[(pix[1], pix[0])]
 
     def _on_acis_streak(self, src):
-        acis_streaks_file = self.workdir / "images" / f"{self.obsid}_acis_streaks.txt"
+        acis_streaks_file = self.file_path(f"images/{self.obsid}_acis_streaks.txt")
         result = np.zeros(len(src), dtype=bool)
         if acis_streaks_file.exists():
             reg = regions.Regions.read(acis_streaks_file)
@@ -834,22 +802,10 @@ class Observation:
             # 'bias': f'{instrument}0[*bias*]',
         }
 
+    @stored_result("calalign", fmt="json", subdir="cache")
     def get_calalign(self):
-        calalign_file = None
-        if (self.workdir / "calalign.json").exists():
-            calalign_file = self.workdir / "calalign.json"
-        if (
-            self.archive_dir is not None
-            and (self.archive_dir / "calalign.json").exists()
-        ):
-            calalign_file = self.archive_dir / "calalign.json"
-
-        if calalign_file:
-            with open(calalign_file) as fh:
-                return json.load(fh)
-
         self.download(["acal"])
-        cal_file = list((self.workdir / "secondary").glob("*acal*fits*"))
+        cal_file = self.file_glob("secondary/*acal*fits*")
         if cal_file:
             hdus = fits.open(cal_file[0])
             calalign = {
@@ -859,9 +815,337 @@ class Observation:
             calalign = {k: v.tolist() for k, v in calalign.items()}
             calalign["obsid"] = int(self.obsid)
             calalign["caldb_version"] = hdus[1].header["CALDBVER"]
-            with open(self.workdir / "calalign.json", "w") as fh:
-                json.dump(calalign, fh)
             return calalign
+
+    def dmcoords(self, name, **kwargs):
+        """
+        Call dmcoords with the given arguments.
+
+        Examples
+        --------
+
+        Get the off-axis angle, given (x, y) "sky" coordinates:
+
+            obs.dmcoords("theta", option="sky", x=4069.94266994267, y=4076.716625716626)
+
+        Get the off-axis angle, given (ra, dec) in celestial ("cel") coordinates:
+
+            obs.dmcoords("theta", option="cel", celfmt="deg", ra=20.46451186, dec=-28.34952557)
+
+        Parameters
+        ----------
+        name: str
+            Name of the output parameter.
+        kwargs: dict
+            Arguments to pass to dmcoords.
+        """
+        self.download(["evt2", "asol"])
+
+        evt = self.file_path(f"primary/{self.obsid}_evt2_filtered.fits.gz")
+        if not evt:
+            raise Exception("Expected ine evt file, there are none")
+
+        asol_files = self.file_glob(f"secondary/*{self.obsid}_*asol*fits*")
+        if len(asol_files) != 1:
+            raise Exception(f"Expected 1 asol file, there are {len(asol_files)}")
+        asol = asol_files[0]
+
+        args = [evt, f"asolfile={asol}"]
+        # if I do not unlearn, the following two calls in succession will hang
+        # obs.dmcoords("theta", option="sky", x=4069.94266994267, y=4076.716625716626)
+        # obs.dmcoords("theta", option="cel", celfmt="deg", ra=20.46451186, dec=-28.34952557)
+        self.ciao("punlearn", "dmcoords", logging_tag=str(self))
+        self.ciao("dmcoords", *args, logging_tag=str(self), **kwargs)
+        value = self.ciao.pget("dmcoords", name, logging_tag=str(self))
+        return np.array(value).astype(float)
+
+
+@task(
+    name="make_images",
+    inputs={
+        "events": "primary/*_evt2.fits*",
+        "filtered_events": "primary/{obsid}_evt2_filtered.fits.gz",
+        "fov": "primary/*_fov1.fits*",
+        "asol_file": "secondary/*asol*fits*",
+        "badpixfile": "primary/*_bpix1.fits*",
+        "maskfile": "secondary/*_msk1.fits*",
+    },
+    optional_inputs={
+        "dtffile": "primary/*_dtf1.fits*",
+    },
+    outputs={
+        "image_file": "images/{obsid}_{band}_thresh.img",
+        "fov": "images/{obsid}.fov",
+        "exposure_file": "images/{obsid}_{band}_thresh.expmap",
+        "psf_file": "images/{obsid}_{band}_thresh.psfmap",
+        "flux": "images/{obsid}_{band}_flux.img",
+        "pileup": "images/{obsid}_pileup.img",
+        "pileup_max": "images/{obsid}_pileup_max.img",
+        "acis_streaks_bkg": "images/{obsid}_acis_streaks_bkg.fits",
+        "acis_streaks": "images/{obsid}_acis_streaks.txt",
+    },
+    download=(["evt2", "fov", "asol", "msk", "bpix", "dtf"]),
+    variables={
+        "band": lambda obs: "wide" if obs.is_hrc else "broad",
+    },
+)
+def make_images(obs, inputs, outputs):
+    """
+    Create image. Also creates the exposure map and psfmap.
+    """
+    bin_size = (4 if obs._rebin else 1) if obs.is_hrc is True else 1
+
+    evt_filt = inputs["filtered_events"]
+    fov_file = inputs["fov"][0]
+
+    logging_tag = str(obs)
+    band = "wide" if obs.is_hrc is True else "broad"
+    ciao = obs.ciao
+    obsid = obs.obsid
+
+    process = subprocess.Popen(
+        ["dmlist", f"{evt_filt}[2]", "count"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=ciao.env,
+    )
+    output, _ = process.communicate()
+    n_events = int(output)
+    if n_events <= 0:
+        msg = f"{obsid}   No events in {evt_filt.relative_to(evt_filt.parent.parent)}"
+        return ReturnCode.SKIP, msg
+
+    kwargs = {}
+    if "dtffile" in inputs:
+        kwargs["dtffile"] = inputs["dtffile"][0]
+
+    ciao(
+        "fluximage",
+        infile=evt_filt,
+        outroot=outputs["image_file"].parent / f"{obsid}",
+        # not setting aspect solution file because there can be more than one,
+        # and fluximage does a better job at finding the correct one.
+        # asolfile=inputs["asol_file"][0],
+        badpixfile=inputs["badpixfile"][0],
+        maskfile=inputs["maskfile"][0],
+        bands=band,
+        binsize=bin_size,
+        psfecf=0.9,
+        background="none",
+        logging_tag=logging_tag,
+        clobber="yes",  # clobber will overwrite partially archived results
+        **kwargs,
+    )
+    if obs.is_acis:
+        pileup_file = outputs["pileup"]
+        pileup_max_file = outputs["pileup_max"]
+        ciao(
+            "pileup_map",
+            infile=outputs["image_file"],
+            outfile=pileup_file,
+            clobber="yes",
+            logging_tag=logging_tag,
+        )
+        ciao(
+            "dmimgfilt",
+            infile=pileup_file,
+            outfile=pileup_max_file,
+            fun="max",
+            mask="circle(0,0,3)",
+            clobber="yes",
+            logging_tag=logging_tag,
+        )
+        try:
+            ciao(
+                "acis_streak_map",
+                infile=inputs["events"],
+                fovfile=fov_file,
+                bkgroot=outputs["acis_streaks_bkg"],
+                regfile=outputs["acis_streaks"],
+                msigma="4",
+                clobber="yes",
+                logging_tag=logging_tag,
+            )
+        except Exception:
+            logger.warning(f"{obsid}   acis_streak_map failed")
+
+
+@task(
+    name="wavdetect",
+    inputs={
+        "image_file": "images/{obsid}_{band}_thresh.img",
+        "psf_file": "images/{obsid}_{band}_thresh.psfmap",
+        "exposure_file": "images/{obsid}_{band}_thresh.expmap",
+    },
+    outputs={
+        "src": "sources/{obsid}_baseline.src",
+        "cell": "sources/{obsid}_baseline.cell",
+        "img": "sources/{obsid}_baseline.img",
+        "nbkg": "sources/{obsid}_baseline.nbkg",
+    },
+    variables={
+        "band": lambda obs: "wide" if obs.is_hrc else "broad",
+    },
+)
+def wavdetect(obs, inputs, outputs):
+    """
+    Run wavdetect.
+    """
+    # possible parameter:
+    scales = ["1.4", "2", "4", "8", "16", "32"]
+
+    # if wavdetect fails, it tries again removing the largest two scales
+    for _ in range(2):
+        try:
+            obs.ciao(
+                "wavdetect",
+                infile=inputs["image_file"],
+                expfile=inputs["exposure_file"],  # exposure map
+                psffile=inputs["psf_file"],  # PSF
+                outfile=outputs["src"],
+                scellfile=outputs["cell"],
+                imagefile=outputs["img"],
+                defnbkgfile=outputs["nbkg"],
+                scales=" ".join(scales),
+                clobber="yes",
+                logging_tag=str(obs),
+            )
+        except Exception:
+            scales = scales[:-1]
+            if len(scales) < 3:
+                raise
+    return ReturnCode.OK
+
+
+@task(
+    name="celldetect",
+    inputs={
+        "image_file": "images/{obsid}_{band}_thresh.img",
+        "psf_file": "images/{obsid}_{band}_thresh.psfmap",
+    },
+    outputs={
+        "src": "sources/{obsid}_celldetect.src",
+    },
+    variables={
+        "band": lambda obs: "wide" if obs.is_hrc else "broad",
+    },
+)
+def celldetect(obs, inputs, outputs):
+    """
+    Run celldetect.
+    """
+    # possible parameter:
+    snr = 3
+
+    obs.ciao(
+        "celldetect",
+        inputs["image_file"],
+        outputs["src"],
+        psffile=inputs["psf_file"],  # either this or set fixedcell=
+        thresh=snr,
+        maxlogicalwindow=2048,
+        clobber="yes",
+        logging_tag=str(obs),
+    )
+
+    return ReturnCode.OK
+
+
+@task(
+    name="filter_events",
+    inputs={
+        "events": "primary/*_evt2.fits*",
+        "fov": "primary/*_fov1.fits*",
+    },
+    outputs={
+        "events": "primary/{obsid}_evt2_filtered.fits.gz",
+    },
+    download=(["evt2", "fov"]),
+)
+def filter_events(obs, inputs, outputs):
+    """
+    Filter x-ray events outside a radius around the optical axis.
+    """
+    # possible parameter:
+    radius = 180  # radius in arcsec
+
+    # I'm using a fixed pixel size of 0.5 arcsec, but this might need fixing
+    pixel = 1 if obs.is_hrc else 0.5
+
+    evt = inputs["events"][0]
+    evt2 = outputs["events"]
+
+    obs.ciao("dmkeypar", evt, "RA_PNT", logging_tag=str(obs))
+    ra = obs.ciao.pget("dmkeypar", logging_tag=str(obs))
+    obs.ciao("dmkeypar", evt, "DEC_PNT", logging_tag=str(obs))
+    dec = obs.ciao.pget("dmkeypar", logging_tag=str(obs))
+
+    if not ra:
+        raise Exception("RA is not set")
+    if not dec:
+        raise Exception("DEC is not set")
+    obs.ciao("punlearn", "dmcoords", logging_tag=str(obs))
+    obs.ciao(
+        "dmcoords",
+        evt,
+        op="cel",
+        celfmt="deg",
+        ra=ra,
+        dec=dec,
+        logging_tag=str(obs),
+    )
+    x = obs.ciao.pget("dmcoords", "x", logging_tag=str(obs))
+    y = obs.ciao.pget("dmcoords", "y", logging_tag=str(obs))
+    logger.info(f"{obs} filtering circle({x},{y},{radius / pixel}).")
+    obs.ciao(
+        "dmcopy",
+        f"{evt}[(x,y)=circle({x},{y},{radius / pixel})]",
+        evt2,
+        logging_tag=str(obs),
+        clobber="yes",
+    )
+
+
+@task(
+    name="filter_sources",
+    inputs={
+        "events": "primary/{obsid}_evt2_filtered.fits.gz",
+        "src": "sources/{obsid}_baseline.src",
+    },
+    outputs={
+        "src": "sources/{obsid}_filtered.src",
+    },
+    download=(["evt2"]),
+)
+def filter_sources(obs, inputs, outputs):
+    """
+    Filter detected sources outside a radius around the optical axis.
+    """
+    # possible parameters:
+    radius = 180  # radius in arcsec
+    psfratio = 1
+
+    # I don't think the following should be a parameter
+    # I'm using a fixed pixel size of 0.5 arcsec, but this might need fixing
+    pixel = 1 if obs.is_hrc else 0.5
+
+    evt = inputs["events"]
+
+    obs.ciao("dmkeypar", evt, "RA_PNT", logging_tag=str(obs))
+    ra = obs.ciao.pget("dmkeypar", logging_tag=str(obs))
+    obs.ciao("dmkeypar", evt, "DEC_PNT", logging_tag=str(obs))
+    dec = obs.ciao.pget("dmkeypar", logging_tag=str(obs))
+
+    obs.ciao("punlearn", "dmcoords", logging_tag=str(obs))
+    obs.ciao("dmcoords", evt, op="cel", celfmt="deg", ra=ra, dec=dec)
+    x = obs.ciao.pget("dmcoords", "x", logging_tag=str(obs))
+    y = obs.ciao.pget("dmcoords", "y", logging_tag=str(obs))
+    filters = [f"psfratio=:{psfratio}", f"(x,y)=circle({x},{y},{radius / pixel})"]
+    filters = ",".join(filters)
+
+    obs.ciao(
+        "dmcopy", f"{inputs['src']}[{filters}]", outputs["src"], logging_tag=str(obs)
+    )
 
 
 def get_parser():
@@ -905,14 +1189,12 @@ def main():
     """
     Main routine to process a set of observations.
     """
-    from functools import partial
-    from multiprocessing import Pool
-
-    import pyyaks.logger
+    from functools import partial  # noqa: PLC0415
+    from multiprocessing import Pool  # noqa: PLC0415
 
     args = get_parser().parse_args()
 
-    pyyaks.logger.get_logger(name="astromon", level=args.log_level.upper())
+    logger.setLevel(args.log_level.upper())
 
     logger.info(f"workdir: {args.workdir}")
     if args.workdir is None:

--- a/astromon/stored_result.py
+++ b/astromon/stored_result.py
@@ -1,0 +1,416 @@
+import hashlib
+import inspect
+
+# import logging
+# import functools
+import json
+import os
+import pickle
+import shutil
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from astropy.table import Table
+
+
+class StorageProtocol(Protocol):
+    def glob(self, pattern: str) -> list[Path]: ...
+    def path(self, name: str) -> Path: ...
+    def work_path(self, name: str) -> Path: ...
+
+
+class StorableProtocol(Protocol):
+    storage: StorageProtocol
+
+
+class Storage:
+    def __init__(
+        self,
+        workdir: Path = None,
+        archive_dir: Path = None,
+        instance: StorableProtocol = None,
+    ):
+        self.workdir = Path(workdir if workdir else "").expanduser().absolute()
+        self.archive_dir = (
+            Path(archive_dir).expanduser().absolute() if archive_dir else None
+        )
+        self._member = None
+        self.default_regex = []
+
+        if instance is not None:
+            self.workdir = self.workdir / instance.workdir
+            if self.archive_dir is not None:
+                self.archive_dir = self.archive_dir / instance.workdir
+
+        if not self.workdir.exists():
+            self.workdir.mkdir(parents=True)
+
+    def glob(self, pattern: str) -> list[Path]:
+        files = {}
+        if self.archive_dir is not None:
+            files.update(
+                {
+                    pth.relative_to(self.archive_dir): pth
+                    for pth in self.archive_dir.glob(pattern)
+                }
+            )
+        files.update(
+            {pth.relative_to(self.workdir): pth for pth in self.workdir.glob(pattern)}
+        )
+        return list(files.values())
+
+    def path(self, name: str) -> Path:
+        if Path(name).is_absolute():
+            raise ValueError(
+                f"argument to Observation.file_path must be a relative path ({name})"
+            )
+        wp = self.workdir / name
+        if self.archive_dir is not None:
+            ap = self.archive_dir / name
+            if not wp.exists() and ap.exists():
+                return ap
+        return wp
+
+    def work_path(self, name: str) -> Path:
+        name = Path(name)
+        if self.archive_dir is not None and self.archive_dir in name.parents:
+            name = name.relative_to(self.archive_dir)
+        if name.is_absolute() and not (
+            self.archive_dir in name.parents or self.workdir in name.parents
+        ):
+            raise ValueError(
+                f"argument to Observation.file_path must either be a relative path ({name}) "
+                f"or be in the archive or directories ({self.archive_dir}, {self.workdir})"
+            )
+        return self.workdir / name
+
+    def archive(self, *regex: str):
+        """
+        Move files to archive location.
+
+        Parameters
+        ----------
+        regex: list of str
+            Optional. If not given, self.default_regex is used.
+            Files matching any of the strings are arcived in a long-term location.
+        """
+        if self.archive_dir is None:
+            raise RuntimeError("archive destination was not specified")
+
+        regex = regex if regex else self.default_regex
+        destination = self.archive_dir
+        # logger.debug(f"{self} Archiving to {destination}:")
+        for pattern in regex:
+            for src in self.workdir.rglob(f"**/{pattern}"):
+                # logger.debug(f"{self}   - {src}")
+                dest = destination / src.relative_to(self.workdir)
+                if not dest.parent.exists():
+                    dest.parent.mkdir(exist_ok=True, parents=True)
+                if src.is_dir():
+                    if not dest.exists():
+                        dest.mkdir(exist_ok=True, parents=True)
+                    for src_2 in src.glob("**/*"):
+                        if src_2.is_dir():
+                            # Only files are copied. Parent directories are created automatically.
+                            # empty directories are not copied
+                            continue
+                        dest_2 = destination / src_2.relative_to(self.workdir)
+                        if not dest_2.parent.exists():
+                            dest_2.parent.mkdir(exist_ok=True, parents=True)
+                        try:
+                            shutil.copy(src_2, dest_2)
+                        except shutil.SameFileError:
+                            # links to the same file are not copied
+                            pass
+                else:
+                    try:
+                        shutil.copy(src, dest)
+                    except shutil.SameFileError:
+                        pass
+
+    def specialize(self, instance: StorableProtocol):
+        """
+        Return a Storage instance for a specific object.
+        """
+        return Storage(
+            workdir=self.workdir,
+            archive_dir=self.archive_dir,
+            instance=instance,
+        )
+
+    def __repr__(self):
+        workdir = self.workdir
+        archive_dir = self.archive_dir
+        return f"Storage({workdir=}, {archive_dir=})"
+
+
+class StoredResult:
+    def __init__(
+        self,
+        *,
+        func: Callable,
+        name: str = None,
+        fmt: str = None,
+        storage: StorageProtocol = None,
+        instance: StorableProtocol = None,
+        subdir: Path | str = "",
+    ):
+        self.func = func  # the function being decorated
+        self.name = (
+            fullname(func) if name is None else name
+        )  # the name is used to set the filename
+        self.instance = instance
+        self.fmt = "pickle" if fmt is None else fmt
+        self.storage = Storage() if storage is None else storage
+        self._member = None
+        self.subdir = Path(subdir)
+
+        if self.fmt not in FORMATS:
+            raise ValueError(
+                f"Unknown format {fmt}. Available formats: {list(FORMATS.keys())}"
+            )
+
+    def get_filename(self, *args, **kwargs) -> Path:
+        if self.instance is not None:
+            hsh = argument_hash(self.func, self.instance, *args, **kwargs)  # method
+        else:
+            hsh = argument_hash(self.func, *args, **kwargs)  # function
+        filename = f"{self.name}::{hsh}"
+        filename = FORMATS[self.fmt].sanitize_filename(filename)
+        return self.subdir / filename
+
+    def load(self, *args, **kwargs):
+        filename = self.storage.path(self.get_filename(*args, **kwargs))
+        if self.is_valid_result(*args, **kwargs) and filename.exists():
+            return FORMATS[self.fmt].load(filename)
+
+    def run(self, *args, **kwargs) -> Any:
+        if self.instance is not None:
+            result = self.func(self.instance, *args, **kwargs)  # method
+        else:
+            result = self.func(*args, **kwargs)  # function
+        return result
+
+    def save(self, result: Any, *args, **kwargs):
+        filename = self.storage.work_path(self.get_filename(*args, **kwargs))
+        FORMATS[self.fmt].save(result, filename, force=True)
+        invalid = self._invalidate_filename(filename)
+        if invalid.exists():
+            invalid.unlink()
+
+    def is_valid_result(self, *args, **kwargs) -> bool:
+        filename = self.get_filename(*args, **kwargs)
+        invalid = self._invalidate_filename(filename)
+        return not invalid.exists()
+
+    def invalidate_result(self, *args, **kwargs):
+        filename = self.get_filename(*args, **kwargs)
+        invalid = self._invalidate_filename(filename)
+        if not invalid.parent.exists():
+            invalid.parent.mkdir(parents=True, exist_ok=True)
+        with open(invalid, "w"):
+            pass
+
+    def invalidate_all_results(self):
+        for filename in self.storage.glob(f"{self.name}::*"):
+            invalid = self._invalidate_filename(filename)
+            if not invalid.parent.exists():
+                invalid.parent.mkdir(parents=True, exist_ok=True)
+            with open(invalid, "w"):
+                pass
+
+    def files(self) -> list[Path]:
+        return list(self.storage.glob(f"{self.subdir}/{self.name}::*"))
+
+    def _invalidate_filename(self, filename):
+        filename = self.storage.work_path(filename)
+        return filename.parent / f".{filename.name}.invalidated"
+
+    def __call__(self, *args, **kwargs) -> Any:
+        # check if there is a previous result and return it it exists
+        result = self.load(*args, **kwargs)
+        if result is None:
+            # if there is no result, run the function and save the result
+            result = self.run(*args, **kwargs)
+            self.save(result, *args, **kwargs)
+        return result
+
+    def specialize(self, obj):
+        """
+        Return a StoredResult instance for a specific object.
+        """
+        return StoredResult(
+            func=self.func,
+            name=self.name,
+            fmt=self.fmt,
+            storage=obj.storage,
+            subdir=self.subdir,
+            instance=obj,
+        )
+
+
+class StoredResultWrapper(StoredResult):
+    """
+    A wrapper for StoredResult that allows it to be used as a descriptor.
+    """
+
+    def __get__(self, obj, objtype_):
+        # This method is called when the StoredResultWrapper is an attribute of an object.
+        # It returns a new instance of StoredResult with the object as the "instance".
+        return self.specialize(obj)
+
+
+def stored_result(*args, **kwargs) -> Callable:
+    """
+    Decorator to store the result of a function or method call.
+
+        Usage:
+        @store_result(name="my_function", fmt="json")
+        def my_function(...):
+            ...
+    """
+
+    if len(args) == 1 and len(kwargs) == 0:
+        # If the first argument is a callable, we are decorating a function
+        return StoredResultWrapper(func=args[0])
+
+    storage = kwargs.pop("storage", None)
+    name = kwargs.pop("name", None)
+    fmt = kwargs.pop("fmt", None)
+    subdir = kwargs.pop("subdir", "")
+
+    def decorator(func: Callable) -> StoredResult:
+        return StoredResultWrapper(
+            func=func, name=name, fmt=fmt, storage=storage, subdir=subdir
+        )
+
+    return decorator
+
+
+def argument_hash(func, *args, **kwargs):
+    # kwargs are sorted to be consistent. All other arguments are sorted in the signature already.
+    kwargs = {k: kwargs[k] for k in sorted(kwargs)}
+
+    sig = inspect.signature(func)
+    sig_args = sig.bind(*args, **kwargs)
+    sig_args.apply_defaults()
+    sig_args = sig_args.arguments.copy()
+    sig_args.pop("self", None)
+
+    # this cache treats lists and tuple arguments the same way, so you don't get two entries,
+    # one for [1, 2, 3] and one for (1, 2, 3)
+    for k, v in sig_args.items():
+        if isinstance(v, list):
+            sig_args[k] = tuple(v)
+    hsh = hashlib.md5(json.dumps(sig_args).encode()).hexdigest()
+    return hsh
+
+
+def is_writable(dirpath):
+    if sys.platform.startswith("linux"):
+        return os.access(dirpath, os.W_OK)
+
+    dirpath = Path(dirpath)
+    test_file = dirpath / f"{uuid.uuid4()}.txt"
+    try:
+        with open(test_file, "w") as test:
+            test.write("hello")
+            return True
+    except OSError:
+        return False
+    finally:
+        if test_file.exists():
+            test_file.unlink()
+
+
+def fullname(o):
+    module = o.__class__.__module__
+    if module == "builtins":
+        return o.__qualname__  # avoid outputs like 'builtins.str'
+    return f"{module}.{o.__qualname__}"
+
+
+class TableCache:
+    @staticmethod
+    def save(table, filename, force=False):
+        if filename.exists() and not force:
+            return
+        if not filename.parent.exists():
+            filename.parent.mkdir(parents=True, exist_ok=True)
+        if not isinstance(table, Table):
+            table = Table(table)
+        if "description" in table.meta:
+            table.meta["descript"] = table.meta["description"]
+            del table.meta["description"]
+        table.write(filename, overwrite=force)
+
+    @staticmethod
+    def load(filename):
+        if filename.exists():
+            table = Table.read(filename)
+            table.convert_bytestring_to_unicode()
+            return table
+
+    @staticmethod
+    def sanitize_filename(filename):
+        filename = str(filename)
+        if not filename.endswith((".fits", ".fits.gz")):
+            filename = Path(str(filename) + ".fits.gz")
+        return Path(filename)
+
+
+class PickleCache:
+    @staticmethod
+    def save(result, filename, force=False):
+        if filename.exists() and not force:
+            return
+        if not filename.parent.exists():
+            filename.parent.mkdir(parents=True, exist_ok=True)
+        with open(filename, "wb") as fh:
+            pickle.dump(result, fh)
+
+    @staticmethod
+    def load(filename):
+        if filename.exists():
+            with open(filename, "rb") as fh:
+                return pickle.load(fh)
+
+    @staticmethod
+    def sanitize_filename(filename):
+        filename = str(filename)
+        if not (filename.endswith((".pkl", ".pickle"))):
+            filename = filename + ".pkl"
+        return Path(filename)
+
+
+class JsonCache:
+    @staticmethod
+    def save(result, filename, force=False):
+        if filename.exists() and not force:
+            return
+        if not filename.parent.exists():
+            filename.parent.mkdir(parents=True, exist_ok=True)
+        with open(filename, "w") as fh:
+            json.dump(result, fh)
+
+    @staticmethod
+    def load(filename):
+        if filename.exists():
+            with open(filename, "r") as fh:
+                return json.load(fh)
+
+    @staticmethod
+    def sanitize_filename(filename):
+        filename = str(filename)
+        if not (filename.endswith(".json")):
+            filename = filename + ".json"
+        return Path(filename)
+
+
+FORMATS = {
+    "table": TableCache,
+    "json": JsonCache,
+    "pickle": PickleCache,
+}

--- a/astromon/task.py
+++ b/astromon/task.py
@@ -1,0 +1,1032 @@
+import dataclasses
+import functools
+import inspect
+import json
+import logging
+import weakref
+from collections import defaultdict
+from enum import Enum
+from pathlib import Path
+
+import networkx as nx
+from cxotime import CxoTime
+
+logger = logging.getLogger("astromon")
+
+
+class ReturnCode(Enum):
+    """
+    Enum to represent the return codes of a function.
+    """
+
+    OK = 0
+    SKIP = 1
+    WARNING = 2
+    ERROR = 3
+    INVALID = 1000  # for invalidating the result
+
+
+@dataclasses.dataclass
+class ReturnValue:
+    """
+    Class to encapsulate the return value of a function.
+
+    Parameters
+    ----------
+    return_code: ReturnCode
+        The return code of the function call. One of OK, SKIP, WARNING or ERROR.
+    msg: str
+        Optional message to be logged or displayed.
+    """
+
+    return_code: ReturnCode = ReturnCode.OK
+    msg: str = ""
+    actual_outputs: list = dataclasses.field(default_factory=list)
+    inputs: dict = dataclasses.field(default_factory=dict)
+    outputs: dict = dataclasses.field(default_factory=dict)
+    start: CxoTime = dataclasses.field(default_factory=CxoTime.now)
+    stop: CxoTime = dataclasses.field(default_factory=CxoTime.now)
+
+    def __bool__(self):
+        return self.return_code == ReturnCode.OK
+
+    def to_dict(self):
+        """
+        Convert the ReturnValue to a JSON serializable dictionary.
+        """
+        return {
+            "return_code": self.return_code.name,
+            "msg": self.msg,
+            "actual_outputs": self.actual_outputs,
+            "inputs": self.inputs,
+            "outputs": self.outputs,
+            "start": self.start.iso,
+            "stop": self.stop.iso,
+        }
+
+    @staticmethod
+    def from_dict(data):
+        """
+        Populate the ReturnValue from a JSON serializable dictionary.
+        """
+        rv = ReturnValue()
+        rv.return_code = ReturnCode[data["return_code"]]
+        rv.msg = data.get("msg", "")
+        rv.actual_outputs = data.get("actual_outputs", [])
+        rv.inputs = data.get("inputs", {})
+        rv.outputs = data.get("outputs", {})
+        rv.start = CxoTime(data["start"])
+        rv.stop = CxoTime(data["stop"])
+        return rv
+
+
+class Dependent:
+    """
+    Decorator for functions that depend on tasks.
+    """
+
+    def __init__(
+        self,
+        func,
+        manager,
+        instance=None,
+        name=None,
+        tasks=None,
+        required_files=None,
+        optional_files=None,
+        download=None,
+        variables=None,
+    ):
+        """
+        Decorator to run tasks.
+
+        Parameters
+        ----------
+        func: callable
+            The function to be decorated.
+        name: str
+            Name of the task.
+        tasks: list
+            List of task names that this function depends on. An exception is raised if any of
+            these tasks give an error.
+        required_files: dict
+            Dictionary of required input files. An exception is raised if any of these files are
+            missing.
+        optional_files: dict
+            Dictionary of optional input files.
+        download: list
+            List of file categories to download before running the task.
+        variables: dict
+            Dictionary of variables to be used in the task. If a value is a function, it will be
+            called without arguments.
+        """
+        self._instance = instance
+        self._manager = manager
+        self.func = func
+        self.name = _fullname(func) if name is None else name
+        self._tasks = tasks if tasks is not None else []
+        self._required_files = required_files if required_files is not None else {}
+        self._optional_files = optional_files if optional_files is not None else {}
+        self._download = download if download is not None else []
+        self._variables = variables if variables is not None else {}
+        functools.update_wrapper(self, func)
+
+    def __call__(self, *args, **kwargs):
+        """
+        Call the function
+        """
+        if self._instance is None:
+            obs = args[0]
+            args = args[1:]
+        else:
+            obs = self._instance
+
+        if len(args) != 0:
+            raise RuntimeError(
+                "Dependent functions should not take positional arguments."
+            )
+
+        if self._download:
+            obs.download(self._download)
+
+        params = self.get_parameters(obs, **kwargs)
+
+        requested_files = list(
+            set(params["required_files"].values())
+            | set(params["optional_files"].values())
+        )
+
+        rv = self._manager.run_tasks(obs=obs, requested_files=requested_files)
+
+        errors = {
+            name: value
+            for name, value in rv.items()
+            if value.return_code.value >= ReturnCode.ERROR.value
+        }
+        if errors:
+            msg = ", ".join(f"{name} {value.msg}" for name, value in errors.items())
+            raise RuntimeError(f"{self.name} failed. Dependency tasks failed: {msg}")
+
+        missing = {
+            name: value
+            for name, value in params["required_files"].items()
+            if not obs.file_path(value).exists()
+        }
+        if missing:
+            msg = ", ".join(f"{value}" for value in missing.values())
+            raise FileNotFoundError(f"{self.name} failed. Missing files: {msg}")
+
+        return self.func(obs, **kwargs)
+
+    def get_parameters(self, obs, **kwargs):
+        """
+        Get the task parameters for the observation, including variable interpolation.
+        """
+        signature = inspect.signature(self.func)
+        arguments = signature.bind(obs, **kwargs)
+        arguments.apply_defaults()
+
+        variables = {"obsid": obs.obsid}
+        variables.update(
+            {
+                key: value(obs) if callable(value) else value
+                for key, value in self._variables.items()
+            }
+        )
+        variables.update(arguments.arguments)
+
+        parameters = {
+            "required_files": {
+                key: value.format(**variables)
+                for key, value in self._required_files.items()
+            },
+            "optional_files": {
+                key: value.format(**variables)
+                for key, value in self._optional_files.items()
+            },
+            "variables": variables,
+            "download": self._download,
+        }
+        return parameters
+
+
+class Task:
+    """
+    Decorator to run tasks.
+    """
+
+    def __init__(
+        self,
+        func,
+        manager,
+        name=None,
+        inputs=None,
+        optional_inputs=None,
+        outputs=None,
+        download=None,
+        variables=None,
+    ):
+        """
+        Decorator to run tasks.
+
+        Parameters
+        ----------
+        func: callable
+            The function to be decorated.
+        name: str
+            Name of the task.
+        inputs: dict
+            Dictionary of input files.
+        outputs: dict
+            Dictionary of output files.
+        download: list
+            List of file categories to download before running the task.
+        variables: dict
+            Dictionary of variables to be used in the task. If a value is a function, it will be
+            called without arguments.
+        """
+        self._manager = weakref.ref(manager)
+        self.subdir = Path("cache")
+        self.func = func
+        self.name = _fullname(func) if name is None else name
+        self._inputs = inputs if inputs is not None else {}
+        self._optional_inputs = optional_inputs if optional_inputs is not None else {}
+        self._outputs = outputs if outputs is not None else {}
+        self._download = download if download is not None else []
+        self._variables = variables if variables is not None else {}
+        functools.update_wrapper(self, func)
+
+    def __call__(self, obs, requested=None):
+        """
+        Same as Task.run
+        """
+        return self.run(obs, requested=requested)
+
+    def get_parameters(self, obs):
+        """
+        Get the task parameters for the observation, including variable interpolation.
+        """
+        variables = {"obsid": obs.obsid}
+        variables.update(
+            {
+                key: value(obs) if callable(value) else value
+                for key, value in self._variables.items()
+            }
+        )
+        parameters = {
+            "inputs": {
+                key: value.format(**variables) for key, value in self._inputs.items()
+            },
+            "optional_inputs": {
+                key: value.format(**variables)
+                for key, value in self._optional_inputs.items()
+            },
+            "outputs": {
+                key: value.format(**variables) for key, value in self._outputs.items()
+            },
+            "variables": variables,
+            "download": self._download,
+        }
+        return parameters
+
+    def get_filename(self, obs):
+        return obs.file_path(self.subdir / f"task_{self.name}.json")
+
+    def invalidate_result(self, obs, follow_dependents=True):
+        """
+        Invalidate the result of the task.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+        follow_dependents: bool
+            If True, invalidate the result of all dependent tasks as well.
+            If False, only invalidate the result of this task.
+        """
+        manager = self._manager()
+        if manager is None:
+            # we need the manager because we need to know the dependencies
+            raise RuntimeError(
+                "Task manager is not available. Cannot invalidate result."
+            )
+
+        # the cache file can be in the archive or the workdir, so we need to check both
+        # the cache value is not removed, but set to invalid. This is because we can't always
+        # write to the archive directory, but we might still override the cache.
+        rv = self.get_result(obs)
+        # if rv is None, there is nothing to clear
+        if rv is not None:
+            rv.return_code = ReturnCode.INVALID
+            self.set_result(obs, rv)
+
+        logger.debug(f"{obs} Cleared result of task {self.name} in {obs.workdir}.")
+
+        if follow_dependents:
+            for task in manager.get_dependents(self.name).values():
+                task.invalidate_result(obs, follow_dependents=False)
+
+    def get_result(self, obs):
+        """
+        Get the stored result of the task.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+
+        Returns
+        -------
+        ReturnValue or None
+            The stored result of the task, or None if the cache is corrupted or does not exist.
+        """
+        # reading from either the archive or work directories
+        cache_file = obs.file_path(self.subdir / f"task_{self.name}.json")
+        if cache_file.exists():
+            with open(cache_file, "r") as fh:
+                try:
+                    return ReturnValue.from_dict(json.load(fh))
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        f"Cache file {cache_file} is corrupted "
+                        f"({exc}). Task {self.name} must run again."
+                    )
+                    return None
+
+    def set_result(self, obs, return_value):
+        """
+        Set the stored result of the task.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+        return_value: ReturnValue
+            The return value to be stored.
+        """
+        # never writing to the archive directory
+        cache_file = obs.workdir / self.subdir / f"task_{self.name}.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(cache_file, "w") as fh:
+            json.dump(return_value.to_dict(), fh, indent=2)
+
+    def result_is_valid(self, obs):
+        """
+        Check if the task result is valid for the observation.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+
+        Returns
+        -------
+        bool
+            True if the result is valid, False otherwise.
+        """
+        previous_result = self.get_result(obs)
+        # currently, the cache is "valid" if it already run,
+        # but we can invalidate it based on the previous return code, the time stamps of the inputs,
+        # changes in the code, etc.
+        valid = (
+            previous_result is not None
+            and previous_result.return_code != ReturnCode.INVALID
+        )
+        return valid
+
+    def should_run(self, obs, requested=None, unknown_ok=True):
+        """
+        Check if the task should run based on a list of requested outputs.
+
+        This function does the following checks:
+
+            - If the stored result is invalid, the task should run.
+            - If an output in the requested list does not exist, the task should run,
+            - unless the task already ran succesfully and the requested output was not produced.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+        requested: list, optional
+            List of requested outputs. If None, all outputs possible are requested.
+        unknown_ok: bool, optional
+            If True, unknown outputs in the requested list are ignored.
+            If False, an error is raised if an unknown output is requested.
+            Default is True.
+
+        Returns
+        -------
+        bool
+            True if the task should run, False otherwise.
+        """
+
+        if not self.result_is_valid(obs):
+            return True
+
+        params = self.get_parameters(obs)
+
+        possible_outputs = set(params["outputs"].values())
+
+        # if not given, then request all outputs
+        requested = set(possible_outputs if requested is None else requested)
+
+        if not unknown_ok:
+            # check that all the requested outputs are possible outputs of this function
+            unknown_outputs = requested - possible_outputs
+            if unknown_outputs:
+                raise ValueError(
+                    f"Unknown outputs in {self.name} task: {', '.join(unknown_outputs)}"
+                )
+
+        # ignore requests for outputs that were not produced in the previous run
+        if (previous_result := self.get_result(obs)).return_code in [
+            ReturnCode.OK,
+            ReturnCode.SKIP,
+        ]:
+            requested &= set(previous_result.actual_outputs)
+
+        return any(not obs.file_path(value).exists() for value in requested)
+
+    def run(self, obs, requested=None, run_dependencies=False):
+        """
+        Run the task for the observation.
+
+        This function does not dependency checking by default.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+        requested: list, optional
+            List of requested outputs. If None, all outputs possible are requested.
+        run_dependencies: bool, optional
+            If True, resolve and run dependencies and then run the task.
+            If False, only run the task. It expects that the inputs exist. If an input is missing,
+            an exception will be raised.
+
+        Returns
+        -------
+        ReturnValue
+            The return value of the task.
+        """
+        if run_dependencies:
+            manager = self._manager()
+            if manager is None:
+                raise RuntimeError("Task manager is not available.")
+            rv = manager.run_task(obs, self.name)
+        elif self.should_run(obs, requested=requested):
+            rv = self._run(obs)
+        else:
+            rv = self.get_result(obs)
+
+        return rv
+
+    def _run(self, obs):  # noqa: PLR0912
+        """
+        Run the task for the observation.
+
+        This function does not dependency checking by default. It expects that the inputs exist.
+        If an input is missing, an exception will be raised.
+        """
+        start = CxoTime.now()
+
+        # download
+        if self._download:
+            obs.download(self._download)
+
+        params = self.get_parameters(obs)
+
+        inputs = {key: obs.file_path(val) for key, val in params["inputs"].items()}
+        opt_inputs = {
+            key: obs.file_path(val) for key, val in params["optional_inputs"].items()
+        }
+        outputs = {key: obs.file_path(val) for key, val in params["outputs"].items()}
+
+        if set(inputs) & set(opt_inputs):
+            raise ValueError(
+                f"Input and optional input keys cannot overlap in task {self.name}. "
+                f"Inputs: {inputs.keys()}, Optional inputs: {opt_inputs.keys()}"
+            )
+
+        for key, value in inputs.items():
+            if not value.exists():
+                # try with a regex if the input is a glob pattern (e.g. "primary/*_evt2.fits*")
+                if match := list(obs.file_glob(params["inputs"][key])):
+                    inputs[key] = match
+                else:
+                    inputs[key] = None
+
+        for key, value in opt_inputs.items():
+            if not value.exists():
+                # try with a regex if the input is a glob pattern (e.g. "primary/*_evt2.fits*")
+                if match := list(obs.file_glob(params["optional_inputs"][key])):
+                    opt_inputs[key] = match
+                else:
+                    opt_inputs[key] = None
+
+        if any(value is None for value in inputs.values()):
+            missing_inputs = [
+                str(value) for key, value in inputs.items() if value is None
+            ]
+            raise FileNotFoundError(
+                f"Missing input files for task {self.name}: {', '.join(missing_inputs)}"
+            )
+
+        inputs.update(
+            {key: value for key, value in opt_inputs.items() if value is not None}
+        )
+
+        for path in outputs.values():
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+        result = self.func(obs, inputs=inputs, outputs=outputs)
+
+        # for convenience, we allow the return value to be None,
+        # a ReturnCode, or a tuple of (ReturnCode, str)
+        rc = ReturnCode.OK
+        msg = ""
+        if result is not None:
+            if isinstance(result, ReturnCode):
+                rc = result
+            elif isinstance(result, tuple):
+                rc, msg = result
+            else:
+                raise TypeError(
+                    f"Return value of {self.name} must be None, a ReturnCode, "
+                    f"or a tuple of (ReturnCode, str), got {type(result)}"
+                )
+
+        rv = ReturnValue(
+            rc,
+            msg,
+            start=start,
+            stop=CxoTime.now(),
+            inputs=params["inputs"],
+            outputs=params["outputs"],
+            actual_outputs=sorted(
+                [
+                    value
+                    for value in params["outputs"].values()
+                    if obs.file_path(value).exists()
+                ]
+            ),
+        )
+
+        self.set_result(obs, rv)
+
+        return rv
+
+    def skip(self, obs, msg):
+        rv = ReturnValue(
+            return_code=ReturnCode.SKIP,
+            msg=msg,
+        )
+        self.set_result(obs, rv)
+
+
+class TaskManager:
+    """
+    Class to manage tasks.
+    """
+
+    def __init__(self):
+        self.tasks = {}
+        self.task_graph = None
+
+    def register_task(self, task):
+        """
+        Register a task.
+
+        Parameters
+        ----------
+        task: Task
+            The task to register.
+        """
+        if not isinstance(task, Task):
+            raise TypeError("task must be an instance of Task")
+        if task.name in self.tasks:
+            raise ValueError(f"Task {task.name} is already registered.")
+        self.tasks[task.name] = task
+        self._set_dependency_graph()
+
+    def run_task(self, obs, task_name):
+        """
+        Run a task by its name.
+
+        Parameters
+        ----------
+        task_name: str
+            The name of the task to run.
+        obs: Observation
+            The observation object.
+
+        Returns
+        -------
+        ReturnValue
+            A dictionary of return values for each task (requested or run) with task names as keys.
+        """
+        if task_name not in self.tasks:
+            raise ValueError(f"Task {task_name} not found.")
+        return self.run_tasks(obs, [task_name])
+
+    def run_tasks(self, obs, task_names=None, requested_files=None):
+        """
+        Run task by their names.
+
+        If any task fails, execution stops.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+        task_names: list
+            The list of names of the tasks to run.
+        requested_files: list
+            The list of file names to be produced by the tasks.
+
+        Returns
+        -------
+        dict
+            A dictionary of return values for each task (requested or run) with task names as keys.
+        """
+        task_names = [] if task_names is None else task_names
+        requested_files = [] if requested_files is None else requested_files
+
+        tasks = self.get_tasks_to_run(
+            obs, requested_tasks=task_names, requested_files=requested_files
+        )
+
+        # requested tasks with valid stored results will not be run,
+        # but their stored results will be returned because they are requested explicitly.
+        return_values = {
+            name: self.tasks[name].get_result(obs)
+            for name in task_names
+            if name not in tasks
+        }
+
+        skip = defaultdict(list)  # these will be skipped
+        for name, task in tasks.items():
+            for dep in self.get_dependencies(name):
+                if (
+                    self.tasks[dep].get_result(obs).return_code == ReturnCode.SKIP
+                    and dep not in skip[name]
+                ):
+                    skip[name].append(dep)
+
+            if name in skip:
+                # if the task is in the skip list, it means that at least one of its dependencies
+                # was skipped.
+                msg = f"missing dependencies: {', '.join(skip[name])}"
+                logger.info(f"Skipping task {name} for observation {obs.obsid}. {msg}")
+                return_values[name] = ReturnValue(
+                    return_code=ReturnCode.SKIP,
+                    msg=msg,
+                )
+                # setting this here is a hack. Normally, the result is set inside the task,
+                # but I am not running the task, and if I do not set it here, downstream tasks
+                # will not be aware that this task was skipped.
+                task.set_result(obs, return_values[name])
+                continue
+
+            logger.info(f"{obs} Running task {name}.")
+            task.invalidate_result(obs, follow_dependents=False)
+            return_value = task.run(obs)
+            return_values[name] = return_value
+
+            if return_value.return_code.value == ReturnCode.OK.value:
+                logger.info(f"{obs} Task {name} completed successfully.")
+            elif return_value.return_code.value == ReturnCode.SKIP.value:
+                logger.info(f"{obs} Task {name} skipped: {return_value.msg}")
+                for dep in self.get_dependents(name):
+                    skip[dep].append(name)
+            elif return_value.return_code.value == ReturnCode.WARNING.value:
+                logger.warning(f"{obs} Task {name} skipped: {return_value.msg}")
+                for dep in self.get_dependents(name):
+                    skip[dep].append(name)
+            else:
+                logger.error(
+                    f"{obs} Task {name} failed with return code "
+                    f"{return_value.return_code.name}: {return_value.msg}"
+                )
+                break
+        return return_values
+
+    def _set_dependency_graph(self):
+        """
+        Set the dependency graph for the tasks.
+
+        Dependencies are described by a directed acyclic graph (DAG) where nodes are tasks
+        and edges represent dependencies between tasks.
+
+        The graph is built from the inputs and outputs of each task.
+        """
+        task_dependency_graph = nx.DiGraph()
+        for name, task in self.tasks.items():
+            task_dependency_graph.add_node(name, bipartite=0)
+            for fn in task._inputs.values():
+                task_dependency_graph.add_node(fn, bipartite=1)
+            for fn in task._optional_inputs.values():
+                task_dependency_graph.add_node(fn, bipartite=1)
+            for fn in task._outputs.values():
+                task_dependency_graph.add_node(fn, bipartite=1)
+
+        for name, task in self.tasks.items():
+            for fn in task._inputs.values():
+                task_dependency_graph.add_edge(fn, name)
+            for fn in task._optional_inputs.values():
+                task_dependency_graph.add_edge(fn, name)
+            for fn in task._outputs.values():
+                task_dependency_graph.add_edge(name, fn)
+
+        for layer, nodes in enumerate(
+            nx.topological_generations(task_dependency_graph)
+        ):
+            # `multipartite_layout` expects the layer as a node attribute, so add the
+            # numeric layer value as a node attribute
+            for node in nodes:
+                task_dependency_graph.nodes[node]["layer"] = layer
+
+        # check that this is a DAG
+        if not nx.is_directed_acyclic_graph(task_dependency_graph):
+            raise ValueError(
+                "Task dependency graph is not a directed acyclic graph (DAG). "
+                "Check the task dependencies for cycles."
+            )
+
+        # the original graph is bipartite (files are connected only tasks and tasks are connected
+        # only to files). We want the task graph only.
+        self.task_graph = nx.algorithms.bipartite.projected_graph(
+            task_dependency_graph,
+            [name for name, bp in task_dependency_graph.nodes("bipartite") if bp == 0],
+        )
+
+    def get_tasks_to_run(self, obs, requested_tasks=None, requested_files=None):
+        """
+        Get the tasks that need to run for the observation.
+
+        The determination of whether a task needs to run is based on the requested tasks and files.
+        The dependency tree is traversed to ensure that all dependency tasks are included.
+
+        Parameters
+        ----------
+        obs: Observation
+            The observation object.
+        requested_tasks: list, optional
+            List of task names that are requested to run.
+        requested_files: list, optional
+            List of file names that are requested to be produced by the tasks.
+
+        Returns
+        -------
+        dict
+            A dictionary of tasks that need to run, where the keys are task names and the values
+            are Task objects.
+        """
+        unknown_tasks = set(requested_tasks) - set(self.tasks.keys())
+        if unknown_tasks:
+            raise ValueError(
+                f"Unknown tasks requested: {', '.join(unknown_tasks)}. "
+                f"Available tasks: {', '.join(self.tasks.keys())}."
+            )
+
+        requested_files = set() if requested_files is None else set(requested_files)
+        requested_tasks = set() if requested_tasks is None else set(requested_tasks)
+
+        tasks = self.task_graph
+
+        requested_files |= {
+            filename
+            for name in requested_tasks
+            for filename in self.tasks[name].get_parameters(obs)["outputs"].values()
+        }
+
+        # find out which tasks produce the requested files.
+        # and create a dict mapping task names to filenames.
+        # note that these are the filenames _after_ variable interpolation.
+        params = {name: task.get_parameters(obs) for name, task in self.tasks.items()}
+        task_file_map = {
+            name: set(params[name]["outputs"].values()) & requested_files
+            for name in self.tasks
+        }
+        task_file_map = {k: v for k, v in task_file_map.items() if v}
+
+        # define the set of tasks that are possible to run.
+        # This includes the requested tasks, tasks that produce the requested files,
+        # and their ancestors in the dependency graph.
+        possible = set(task_file_map) | requested_tasks
+        possible |= {
+            ancestor for task in possible for ancestor in nx.ancestors(tasks, task)
+        }
+
+        # in the following, we want to iterate over the tasks in "topological order".
+        # This is the order that ensures traversal of the graph in order of dependence.
+        generations = list(nx.topological_generations(tasks))
+
+        # check if the result is valid for each possible task.
+        # ---------------------------------------------------
+        # Note:
+        #   - we move forward in the topological order. This means that when checking each
+        #     task, we have already checked its predecessors
+        #     (a task needs to run if an ancestor's result is invalid).
+        result_is_valid = {}
+        tasks_by_generation_fwd = [
+            name for gen in generations for name in gen if name in possible
+        ]
+        for name in tasks_by_generation_fwd:
+            result_is_valid[name] = self.tasks[name].result_is_valid(obs) and all(
+                result_is_valid[p] for p in tasks.predecessors(name)
+            )
+        # check if each task needs to run to produce the requested files.
+        # ---------------------------------------------------------------
+        # Note:
+        #   - we move backward in the topological order. This means that first we check
+        #     if a task needs to run, and if it does, we use its inputs to determine if the
+        #     ancestors need to run.
+        #   - requested tasks should run.
+        # should_run = {task: False for task in tasks_by_generation_fwd}
+        should_run = {}
+        tasks_by_generation_bwd = [
+            name for gen in generations[::-1] for name in gen if name in possible
+        ]
+        for name in tasks_by_generation_bwd:
+            should_run[name] = self.tasks[name].should_run(obs, requested_files)
+            if should_run[name]:
+                requested_files |= set(params[name]["inputs"].values())
+                requested_files |= set(params[name]["optional_inputs"].values())
+
+        # the final result of whether each task should run is the logical OR of whether:
+        #   - the stored result is invalid,
+        #   - the outputs are requested.
+        return {
+            key: self.tasks[key]
+            for key in tasks_by_generation_fwd
+            if should_run[key] or (not result_is_valid[key])
+        }
+
+    def get_dependencies(self, task_name):
+        """
+        Get the dependencies of a task.
+
+        Parameters
+        ----------
+        task_name: str
+            The name of the task.
+        Returns
+        -------
+        dict
+            A dictionary of tasks on which the given task depends (the ancestors in the DAG).
+        """
+        return {
+            name: self.tasks[name] for name in nx.ancestors(self.task_graph, task_name)
+        }
+
+    def get_dependents(self, task_name):
+        """
+        Get the dependents of a task.
+
+        Parameters
+        ----------
+        task_name: str
+            The name of the task.
+        Returns
+        -------
+        dict
+            A dictionary of tasks that depend on the given task name (the descendents in the DAG).
+        """
+        return {
+            name: self.tasks[name]
+            for name in nx.descendants(self.task_graph, task_name)
+        }
+
+    def task(
+        self,
+        name=None,
+        inputs=None,
+        optional_inputs=None,
+        outputs=None,
+        download=None,
+        variables=None,
+    ):
+        """
+        Decorator to run tasks.
+
+        Parameters
+        ----------
+        name: str
+            Name of the task.
+        inputs: dict
+            Dictionary of input files.
+        optional_inputs: dict
+            Dictionary of optional input files.
+        outputs: dict
+            Dictionary of output files.
+        download: list
+            List of file categories to download before running the task.
+        variables: dict
+            Dictionary of variables to be used in the task. Can be a function, with no arguments.
+        """
+
+        def wrapper(func):
+            task = Task(
+                func,
+                manager=self,
+                name=name,
+                inputs=inputs,
+                optional_inputs=optional_inputs,
+                outputs=outputs,
+                download=download,
+                variables=variables,
+            )
+            self.register_task(task)
+            return task
+
+        return wrapper
+
+    def dependencies(
+        self,
+        name=None,
+        tasks=None,
+        required_files=None,
+        optional_files=None,
+        download=None,
+        variables=None,
+    ):
+        """
+        Decorator to run tasks.
+
+        Parameters
+        ----------
+        tasks: str
+            Name of the task.
+        required_files: list
+            List of required input files. An exception is raised if any of these files are missing.
+        optional_files: list
+            List of optional input files.
+        """
+
+        def wrapper(func):
+            task = DependentWrapper(
+                func,
+                manager=self,
+                name=name,
+                tasks=tasks,
+                required_files=required_files,
+                optional_files=optional_files,
+                download=download,
+                variables=variables,
+            )
+            return task
+
+        return wrapper
+
+
+class DependentWrapper(Dependent):
+    """
+    A wrapper for StoredResult that allows it to be used as a descriptor.
+    """
+
+    def __get__(self, obj, objtype_):
+        # This method is called when the StoredResultWrapper is an attribute of an object.
+        # It returns a new instance of StoredResult with the object as the "instance".
+        task = Dependent(
+            self.func,
+            instance=obj,
+            manager=self._manager,
+            name=self.name,
+            tasks=self._tasks,
+            required_files=self._required_files,
+            optional_files=self._optional_files,
+            download=self._download,
+            variables=self._variables,
+        )
+        return task
+
+
+def _fullname(o):
+    if hasattr(o, "name"):
+        return o.name
+    module = o.__class__.__module__
+    if module == "builtins":
+        return o.__qualname__  # avoid outputs like 'builtins.str'
+    return f"{module}.{o.__qualname__}"
+
+
+TASKS = TaskManager()
+
+task = TASKS.task
+dependencies = TASKS.dependencies
+
+
+def run_tasks(obs, task_names=None, requested_files=None):
+    """
+    Run a list of tasks for an observation.
+
+    Parameters
+    ----------
+    task_names: list
+        List of task names to run.
+    obs: Observation
+        The observation object.
+    """
+    return TASKS.run_tasks(obs, task_names, requested_files)

--- a/astromon/tests/test_stored_result.py
+++ b/astromon/tests/test_stored_result.py
@@ -1,0 +1,528 @@
+import contextlib
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from astromon.stored_result import Storage, StoredResult, stored_result
+
+
+def get_sum(a, b):
+    return a + b
+
+
+def get_diff(a, b):
+    return a - b
+
+
+def get_log(a, base=10):
+    return np.log(a) / np.log(base)
+
+
+def get_random(seed=None):
+    return np.random.rand()
+
+
+class GetLog:
+    def get_log_member(self, a, base=10):
+        return get_log(a, base)
+
+
+get_log_instance = GetLog()
+
+
+@pytest.fixture
+def temp_storage():
+    with tempfile.TemporaryDirectory() as td:
+        storage = Storage(workdir=td)
+        yield storage
+
+
+@pytest.fixture
+def temp_archived_storage():
+    with tempfile.TemporaryDirectory() as work, tempfile.TemporaryDirectory() as arch:
+        storage = Storage(workdir=work, archive_dir=arch)
+        yield storage
+
+
+# this fixture is used automatically for all tests to avoid polluting the current working directory
+@pytest.fixture(autouse=True)
+def tmp_cwd():
+    with tempfile.TemporaryDirectory() as td, contextlib.chdir(td):
+        yield Path(td)
+
+
+@pytest.fixture
+def tmp_archive():
+    with tempfile.TemporaryDirectory() as td, contextlib.chdir(td):
+        yield Path(td)
+
+
+def test_stored_result_constructor():
+    # should raise TypeError
+    with pytest.raises(TypeError):
+        StoredResult()
+
+    # should raise TypeError (no positional arguments)
+    with pytest.raises(TypeError):
+        StoredResult(get_random)
+
+    sr1 = StoredResult(func=get_random)
+    assert sr1.name == "get_random"
+
+    sr2 = StoredResult(func=get_random, name="func.get_random")
+    assert sr2.name == "func.get_random"
+
+    sr1 = StoredResult(func=get_random, subdir="cache")
+    assert sr1.name == "get_random"
+    assert f"{sr1.subdir}" == "cache"
+
+    # NOTE: this is not exactly how it's called
+    sr3 = StoredResult(func=GetLog.get_log_member, instance=get_log_instance)
+    assert sr3.name == "GetLog.get_log_member", (
+        "Name should be derived from the instance method"
+    )
+    assert sr3.instance == get_log_instance, "Instance should be set correctly"
+
+    # NOTE: this could have raised an exception as the "instance" does not have the method
+    # with pytest.raises(AttributeError):
+    #     StoredResult(func=get_log_instance.get_log, instance=get_log)
+
+
+def test_format_filename(temp_storage):
+    sr = StoredResult(func=get_sum, storage=temp_storage, fmt="json")
+    assert sr.fmt == "json", "Format should be set to 'json'"
+    assert sr.get_filename(1, 2).suffix == ".json", "Filename should have .json suffix"
+
+    sr = StoredResult(func=get_diff, storage=temp_storage, fmt="pickle")
+    assert sr.fmt == "pickle", "Format should be set to 'pickle'"
+    assert sr.get_filename(1, 2).suffix == ".pkl", "Filename should have .pkl suffix"
+
+    sr = StoredResult(func=get_log, storage=temp_storage, fmt="table")
+    assert sr.fmt == "table", "Format should be set to 'table'"
+    assert sr.get_filename(1, 2).name.endswith(".fits.gz"), (
+        "Filename should have .fits.gz suffix"
+    )
+
+
+def test_filename(temp_storage):
+    sr1 = StoredResult(func=get_log, storage=temp_storage)
+    path_1_1 = sr1.get_filename(2)
+    path_1_2 = sr1.get_filename(2, base=10)
+    path_1_3 = sr1.get_filename(2, 10)
+
+    assert isinstance(path_1_1, Path), "Filename should be a Path object"
+    assert not path_1_1.is_absolute(), "Filename should not be absolute"
+    assert path_1_1.name.startswith("get_log"), (
+        "Filename should start with the function name"
+    )
+
+    assert path_1_1 == path_1_2, (
+        "Filename should be the same for different keyword arguments"
+    )
+    assert path_1_2 == path_1_3, (
+        "Filename should be the same regardless of keyword or positional arguments"
+    )
+
+    path_2 = sr1.get_filename(2, base=2)
+    assert path_1_1 != path_2, "Filename should be different for different arguments"
+
+
+def test_files():
+    sr = StoredResult(func=get_sum)
+    assert len(sr.files()) == 0, (
+        "Files should be empty before the function is ever called"
+    )
+    sr(1, 2)
+    sr(3, 4)
+    assert len(sr.files()) == 2, (
+        "Files should contain two files after the function is called"
+    )
+    for f in sr.files():
+        # NOTE: this is different from the get_filename method, which returns relative path!
+        assert f.is_absolute(), "File paths should be absolute"
+        assert f.name.startswith("get_sum"), (
+            "File name should start with the function name"
+        )
+
+
+def test_call():
+    # the "call" method tries to load the result and calls the function and saves the result if needed
+    sr1 = StoredResult(func=get_log)
+    assert sr1.storage.path(sr1.get_filename(2)).exists() is False, (
+        "Filename should not exist before the function is called"
+    )
+    assert sr1(2) == get_log(2), (
+        "StoredResult should return the same value returned by the function"
+    )
+    # the following is True only because of the tmp_cwd fixture, which is used automatically
+    # and changes the current working directory.
+    assert sr1.storage.path(sr1.get_filename(2)).exists(), (
+        "Filename should exist after the function is called"
+    )
+
+
+def test_run():
+    # NOTE: this works. Is it the required behavior?
+    # the "run" method calls the function directly (no save/load)
+    sr1 = StoredResult(func=get_log)
+    sr2 = StoredResult(func=GetLog.get_log_member, instance=get_log_instance)
+    assert sr1.run(2) == get_log(2)
+    assert sr1.run(2) == sr2.run(2)
+
+
+def test_save_n_load():
+    sr1 = StoredResult(func=get_log)
+    assert sr1.storage.path(sr1.get_filename(2)).exists() is False, (
+        "Filename should not exist before the function is called"
+    )
+
+    # NOTE: this one is currently returning None instead of raising an error
+    # with pytest.raises(FileNotFoundError):
+    #     sr1.load(2, base=10)
+
+    sr1.save(125, 2, base=10)
+    assert sr1.load(2, base=10) == 125
+    assert sr1(2) == 125, "Function should return the correct value"
+
+    sr1.invalidate_result(2, base=10)
+    # NOTE: the following should raise some sort of error, because the result is invalid,
+    # but currently it returns None, so it is not possible to know the difference between
+    # and invalid result and a function returning None
+    # with pytest.raises(RuntimeError):
+    #     sr1.load(2, base=10)
+
+
+@pytest.mark.parametrize(["subdir"], [("",), ("cache",)])
+def test_invalidate(subdir):
+    sr = StoredResult(func=get_random, subdir=subdir)
+    sr.invalidate_result()  # invalidate a result that does not exist should be no-op
+
+    value = sr()
+    assert sr() == value, "StoredResult should return the same value as the first call"
+    sr.invalidate_result()
+    # NOTE: this fails because invalidate does not remove the file
+    # assert len(sr.files()) == 0, "Files should contain no files after invalidated"
+    value_2 = sr()
+    assert value_2 != value, (
+        "StoredResult should return a different value after invalidation"
+    )
+    # calling again in case the function ran last time and gave the right result, but wasn't cached
+    assert sr() == value_2, (
+        "StoredResult should return the first value returned after invalidation"
+    )
+
+
+@pytest.mark.parametrize(["subdir"], [("",), ("cache",)])
+def test_invalidate_all(subdir):
+    sr = StoredResult(func=get_random, subdir="")
+    assert len(sr.files()) == 0, "Files should contain no files at the start"
+    sr.invalidate_all_results()  # invalidate all results that do not exist should be no-op
+    # sanity check
+
+    value_1 = sr()
+    value_2 = sr(2)
+    assert value_1 != value_2, "StoredResult should return different values"
+    assert sr() == value_1, (
+        "StoredResult should return the same value as the first call"
+    )
+    assert sr(2) == value_2, (
+        "StoredResult should return the same value as the second call"
+    )
+    assert len(sr.files()) == 2, (
+        "Files should contain two files after the function is called"
+    )
+    sr.invalidate_all_results()
+    # NOTE: this fails because invalidate does not remove the file
+    # assert len(sr.files()) == 0, "Files should contain no files after invalidated"
+    value_1_2 = sr()
+    value_2_2 = sr(2)
+    assert value_1_2 != value_1, (
+        "StoredResult should return a different value after invalidation"
+    )
+    assert value_2_2 != value_2, (
+        "StoredResult should return a different value after invalidation"
+    )
+    # calling again in case the function ran last time and gave the right result, but wasn't cached
+    assert sr() == value_1_2, (
+        "StoredResult should return the first value returned after invalidation"
+    )
+    assert sr(2) == value_2_2, (
+        "StoredResult should return the second value returned after invalidation"
+    )
+
+
+def test_stored_result_method():
+    class Data:
+        def __init__(self, i):
+            self.workdir = f"whatever_{i}"
+            self.storage = Storage("test_dir_1", instance=self)
+
+        @stored_result
+        def method_1(self):
+            pass
+
+        @stored_result
+        def method_2(self):
+            pass
+
+        @stored_result
+        def my_function(self, a, b):
+            """A simple function that adds two numbers."""
+            time.sleep(2)
+            return a - b
+
+    data = Data(1)
+    assert data.method_1.name != data.method_2.name
+    assert data.method_1.name != data.my_function.name
+
+    data_2 = Data(2)
+
+    assert data.storage.workdir != data_2.storage.workdir, (
+        "Workdirs should be different for different instances"
+    )
+
+    # directories are empty to begin with
+    assert not data.storage.path(data.my_function.get_filename(1, 2)).exists()
+
+    filename = data.storage.path(data.my_function.get_filename(1, 2))
+    assert not filename.exists()
+    start = time.time()
+    data.my_function(1, 2)  # This will call the function and save the result
+    stop = time.time()
+    assert stop - start > 2
+    assert filename.exists()
+    start = time.time()
+    data.my_function(1, 2)  # This will call the function and save the result
+    stop = time.time()
+    assert stop - start < 0.1
+    assert filename.exists()
+
+    # just checking that the filename portion of the path depends only on args and kwargs
+    storage = Storage("test_dir_1")
+
+    @stored_result(storage=storage)
+    def my_function(a, b):
+        """A simple function that adds two numbers."""
+        return a - b
+
+    assert str(data.my_function.get_filename(1, 2)) == str(
+        my_function.get_filename(1, 2)
+    ).replace("my_function", "Data.my_function")
+
+
+def test_stored_result_function():
+    storage = Storage("test_dir_1", "test_dir_2")
+
+    @stored_result(storage=storage, name="my_function")
+    def my_function(x, y):
+        """
+        A simple function that adds two numbers.
+        """
+        time.sleep(2)
+        return x + y
+
+    filename = storage.path(my_function.get_filename(1, 2))
+    assert not filename.exists()
+    start = time.time()
+    my_function(1, 2)  # This will call the function and save the result
+    stop = time.time()
+    assert stop - start > 2
+    assert filename.exists()
+    assert len(my_function.files()) == 1, "Function files should contain one file"
+    assert str(my_function.get_filename(1, 2)) == my_function.files()[0].name, (
+        "Function files should contain the result file"
+    )
+
+    start = time.time()
+    my_function(1, 2)  # This will call the function and save the result
+    stop = time.time()
+    assert stop - start < 0.1
+
+    # archive and remove the file from the workdir
+    storage.archive("my_function::*")
+    filename.unlink(missing_ok=True)  # remove the file from the workdir
+
+    assert len(my_function.files()) == 1, "Function files should contain one file"
+    assert storage.archive_dir in my_function.files()[0].parents, (
+        "Function files should be in the archive directory now"
+    )
+    assert str(my_function.get_filename(1, 2)) == my_function.files()[0].name, (
+        "Function files should contain the result file"
+    )
+
+    start = time.time()
+    my_function(1, 2)
+    stop = time.time()
+    assert stop - start < 0.1
+    # the result is stored in the archive
+    assert storage.path(my_function.get_filename(1, 2)).exists()
+    assert storage.archive_dir in storage.path(my_function.get_filename(1, 2)).parents
+
+    # invalidate the result
+    my_function.invalidate_result(1, 2)
+
+    # the result is still there (invalidating the result should not change the archive)
+    assert storage.path(my_function.get_filename(1, 2)).exists()
+
+    # now it should take time again
+    start = time.time()
+    my_function(1, 2)
+    stop = time.time()
+    assert stop - start > 2, "invalidate_result call did not invalidate result"
+
+    start = time.time()
+    my_function(1, 2)
+    stop = time.time()
+    assert stop - start < 0.1, "value not stored after invalidate_result call"
+
+    # invalidate all results
+    my_function.invalidate_all_results()
+
+    # now it should take time again
+    start = time.time()
+    my_function(1, 2)
+    stop = time.time()
+    assert stop - start > 2, "invalidate_all_results call did not invalidate result"
+
+    start = time.time()
+    my_function(1, 2)  # This will call the function and save the result
+    stop = time.time()
+    assert stop - start < 0.1, "value not srored after invalidate_all_results call"
+
+
+def test_stored_result_method_args():
+    storage = Storage("test_dir_1")
+
+    class Data:
+        def __init__(self, i=0):
+            self.workdir = f"whatever_{i}"
+            self.storage = storage.specialize(instance=self)
+
+        @stored_result(name="name", fmt="json", subdir="cache")
+        def name(self, a, b):
+            """A simple function that adds two numbers."""
+            time.sleep(2)
+            return (a, b)
+
+    data = Data()
+    dat = data.name("a", 1)
+
+    assert dat == ("a", 1)
+    assert len(data.name.files()) > 0, "Cache directory should contain the result file"
+
+
+def test_storage_path():
+    with tempfile.TemporaryDirectory() as td, contextlib.chdir(td):
+        storage = Storage("test_dir_1", "archive_dir_1")
+
+        path_w = storage.path("test_file.txt")  # should be in the workdir
+        assert path_w.is_absolute(), "Path should be absolute"
+        assert storage.workdir in path_w.parents, "Path should be in the workdir"
+
+        with open(path_w, "w") as fh:
+            fh.write("Hello, world!")
+        storage.archive("test_file.txt")  # archive the file
+
+        assert storage.workdir in storage.path("test_file.txt").parents, (
+            "Path should be in workdir (takes precedence over archive)"
+        )
+        path_w.unlink()
+
+        path_a = storage.path("test_file.txt")
+        assert path_a.is_absolute(), "Path should be absolute"
+        assert storage.archive_dir in path_a.parents, "Path should be in the archive"
+
+        work_path = storage.work_path("test_file.txt")
+        assert work_path == path_w
+        work_path = storage.work_path(path_a)
+        assert work_path == path_w
+
+
+def test_storage():
+    with tempfile.TemporaryDirectory() as td, contextlib.chdir(td):
+        storage = Storage("test_dir_1")
+        assert storage.workdir == Path("test_dir_1").absolute()
+        assert storage.workdir.exists()
+        assert storage.archive_dir is None
+
+        with pytest.raises(RuntimeError):
+            storage.archive()  # raises exception because the archive is not given
+
+        # creating a storage with workdir and archive_dir
+        storage = Storage("test_dir_1", "test_dir_2")
+        assert storage.workdir == Path("test_dir_1").absolute()
+        assert storage.archive_dir == Path("test_dir_2").absolute()
+        filename = storage.path("test_1.txt")
+        with open(filename, "w") as fh:
+            fh.write("Hello, world!")
+
+        # archiving the default (nothing is archive)
+        storage.archive()
+        assert not storage.archive_dir.exists()
+
+        # archiving the file now
+        storage.archive("test_*")
+        assert storage.archive_dir.exists()
+
+        # Create a new storage with same archive, different workdir
+        storage = Storage("test_dir_3", "test_dir_2")
+        assert storage.archive_dir.exists()
+        # now the file should be in the archive
+        filename = storage.path("test_1.txt")
+        assert filename.exists()
+        assert filename == storage.archive_dir / "test_1.txt"
+        assert storage.archive_dir in filename.parents
+        with open(storage.archive_dir / "test_1.txt", "r") as fh:
+            assert fh.read() == "Hello, world!"
+
+        # create a second file
+        filename = storage.workdir / "test_2.txt"
+        with open(filename, "w") as fh:
+            fh.write("Hello, again!")
+
+        # a glob should return both files (one in the archive, one in the workdir)
+        assert storage.glob("test*") == [
+            Path("test_dir_2/test_1.txt").absolute(),
+            Path("test_dir_3/test_2.txt").absolute(),
+        ]
+
+        # overwriting the first file in the workdir
+        with open(storage.workdir / "test_1.txt", "w") as fh:
+            fh.write("Hello, world!")
+
+        # now the glob should return both files in the workdir
+        assert storage.glob("test*") == [
+            Path("test_dir_3/test_1.txt").absolute(),
+            Path("test_dir_3/test_2.txt").absolute(),
+        ]
+
+        class Data:
+            storage = Storage("test_dir_1")
+
+        data = Data()
+        # with pytest.raises(AttributeError):
+        #     _ = data.storage.workdir  # raises AttributeError: 'Data' object has no attribute 'workdir'
+
+    with tempfile.TemporaryDirectory() as td, contextlib.chdir(td):
+        # now check that workdir and archive_dir are set correctly in the instance
+        class Data:
+            def __init__(self):
+                self.workdir = "whatever"
+                self.storage = Storage("test_dir_1", instance=self)
+
+        data = Data()
+        assert data.storage.workdir == Path("test_dir_1/whatever").absolute()
+        assert data.storage.archive_dir is None
+
+        class Data:
+            def __init__(self):
+                self.workdir = "whatever"
+                self.storage = Storage("test_dir_1", "test_dir_2", instance=self)
+
+        data = Data()
+
+        assert data.storage.workdir == Path("test_dir_1/whatever").absolute()
+        assert data.storage.archive_dir == Path("test_dir_2/whatever").absolute()

--- a/astromon/tests/test_task.py
+++ b/astromon/tests/test_task.py
@@ -1,0 +1,667 @@
+import os
+import tempfile
+from pprint import pprint
+from unittest.mock import Mock
+
+import pytest
+
+from astromon import observation, stored_result, task
+
+
+class MockTaskManager(task.TaskManager):
+    """
+    A mock task manager that has a Mock inner_function that can be called by tasks."""
+
+    def __init__(self):
+        super().__init__()
+        self.inner_function = Mock()
+
+
+def _call_args_list(mock):
+    return [c.args for c in mock.call_args_list]
+
+
+def get_obs(obsid):
+    workdir = tempfile.TemporaryDirectory()
+    archive_dir = tempfile.TemporaryDirectory()
+
+    return observation.Observation(
+        obsid, workdir=workdir.name, archive_dir=archive_dir.name
+    )
+
+
+@pytest.fixture()
+def test_obs():
+    yield get_obs("8007")
+
+
+@pytest.fixture()
+def test_pipeline():
+    manager = MockTaskManager()
+
+    @manager.task(
+        name="one",
+        outputs={
+            "one": "test/one_1.txt",
+            "two": "test/one_2.txt",  # this one is not created
+            "three": "test/one_3.txt",
+        },
+    )
+    def one(obs, inputs, outputs):
+        manager.inner_function("one", obs.obsid)
+        with open(outputs["one"], "w") as f:
+            f.write("This is test file one for task one.\n")
+        with open(outputs["three"], "w") as f:
+            f.write("This is test file three for task one.\n")
+
+    @manager.task(
+        name="two",
+        inputs={
+            "one": "test/one_1.txt",
+        },
+        outputs={
+            "two": "test/two_{obsid}_1.txt",
+        },
+    )
+    def two(obs, inputs, outputs):
+        manager.inner_function("two", obs.obsid)
+        with open(inputs["one"], "r") as f:
+            content = f.read()
+        with open(outputs["two"], "w") as f:
+            f.write(
+                f"This is test file one for task two, reading from {inputs['one']}:\n{content}"
+            )
+
+    @manager.task(
+        name="three",
+        inputs={
+            "one": "test/one_1.txt",
+            # "two": "test/one_2.txt",
+        },
+        outputs={
+            "one": "test/three_1.txt",
+            "two": "test/three_2.txt",
+        },
+    )
+    def three(obs, inputs, outputs):
+        manager.inner_function("three", obs.obsid)
+        with open(outputs["two"], "w") as f:
+            f.write("This is test file two for task three.\n")
+
+    @manager.task(
+        name="four",
+        inputs={
+            "one": "test/two_{obsid}_1.txt",
+            "two": "test/three_2.txt",
+        },
+        outputs={
+            "one": "test/four_{obsid}_1.txt",
+            "two": "test/four_{obsid}_2.txt",  # this one is not created
+        },
+    )
+    def four(obs, inputs, outputs):
+        manager.inner_function("four", obs.obsid)
+        with open(inputs["one"], "r") as f:
+            content = f.read()
+        with open(outputs["one"], "w") as f:
+            f.write(
+                f"This is test file one for task two, reading from {inputs['one']}:\n{content}"
+            )
+
+    @manager.task(
+        name="five",
+        outputs={
+            "two": "test/five_{band}_1.txt",
+        },
+        variables={
+            "band": lambda obs: "wide" if obs.is_hrc else "broad",
+        },
+    )
+    def five(obs, inputs, outputs):
+        manager.inner_function("five", obs.obsid)
+        with open(outputs["two"], "w") as f:
+            f.write("This is test file one for task five")
+
+    @manager.task(
+        name="eight",
+        outputs={
+            "one": "test/eight.txt",  # this one is not created
+        },
+    )
+    def eight(obs, inputs, outputs):
+        manager.inner_function("eight", obs.obsid)
+
+    @manager.task(
+        name="six",
+        inputs={
+            "one": "test/four_{obsid}_1.txt",
+        },
+        optional_inputs={
+            "two": "test/three_2.txt",
+            "three": "test/eight.txt",  # this one is not created
+        },
+        outputs={
+            "one": "test/six_{obsid}_1.txt",
+        },
+    )
+    def six(obs, inputs, outputs):
+        manager.inner_function("six", obs.obsid)
+        with open(inputs["one"], "r") as f:
+            content = f.read()
+        with open(outputs["one"], "w") as f:
+            f.write(
+                f"This is test file one for task six, reading from {inputs['one']}:\n{content}"
+            )
+
+    @manager.task(
+        name="seven",
+        inputs={
+            "one": "test/four_{obsid}_1.txt",
+        },
+        outputs={
+            "one": "test/seven_{obsid}_1.txt",
+        },
+    )
+    def seven(obs, inputs, outputs):
+        manager.inner_function("seven", obs.obsid)
+        with open(inputs["one"], "r") as f:
+            content = f.read()
+        with open(outputs["one"], "w") as f:
+            f.write(
+                f"This is test file one for task seven, reading from {inputs['one']}:\n{content}"
+            )
+
+    return manager
+
+
+def test_a_precondition_dependency_list(test_pipeline):
+    pprint(list(test_pipeline.task_graph.edges()))
+    assert set(test_pipeline.task_graph.edges()) == {
+        ("one", "two"),
+        ("one", "three"),
+        ("two", "four"),
+        ("three", "four"),
+        ("three", "six"),
+        ("four", "six"),
+        ("four", "seven"),
+        ("eight", "six"),
+    }, "Precondition for tests failed"
+
+
+def test_dependency_check(test_pipeline):
+    # test that the input files are checked
+    obs = get_obs("8007")
+    one = test_pipeline.tasks["one"]
+    two = test_pipeline.tasks["two"]
+    with pytest.raises(FileNotFoundError):
+        two(obs)
+    one(obs)
+    two(obs)
+
+
+def test_task_should_run_one(test_pipeline):
+    # this function checks when a function should run
+    # - if the cache is invalidated
+    # - if the output files are missing (except ones that did not exist when the task was run)
+    obs = get_obs("8007")
+    obs2 = get_obs("8008")
+    one = test_pipeline.tasks["one"]
+
+    assert test_pipeline.tasks["one"].should_run(obs), "Task one should run initially"
+    one(obs)
+    assert not test_pipeline.tasks["one"].should_run(obs), (
+        "Task one should not run after execution."
+    )
+    assert os.path.exists(obs.file_path("test/one_1.txt")), (
+        "Output file one_1.txt should exist after task one execution."
+    )
+    assert not os.path.exists(obs.file_path("test/one_2.txt")), (
+        "Output file one_2.txt should not exist after task one execution."
+    )
+    assert not test_pipeline.tasks["one"].should_run(obs, {"test/one_2.txt"}), (
+        "Task one should not run after execution if it is a known missing file (1)."
+    )
+    assert not test_pipeline.tasks["one"].should_run(obs, {"test/one_3.txt"}), (
+        "Task one should not run after execution."
+    )
+
+    # we now remove the output file to simulate a missing file
+    obs.file_path("test/one_3.txt").unlink(missing_ok=True)
+    assert not test_pipeline.tasks["one"].should_run(obs, {"test/one_2.txt"}), (
+        "Task one should not run after execution if it is a known missing file (2)."
+    )
+    assert test_pipeline.tasks["one"].should_run(obs), (
+        "Task one should run after execution if an output file is missing, even if cache is valid."
+    )
+
+    one.invalidate_result(obs)
+    assert test_pipeline.tasks["one"].should_run(obs), (
+        "Task one should run after cache clear."
+    )
+    one(obs)
+    assert not test_pipeline.tasks["one"].should_run(obs), (
+        "Task one should not run after cache clear."
+    )
+    one.invalidate_result(obs2)
+    assert not test_pipeline.tasks["one"].should_run(obs), (
+        "Task one should not run after cache clear on a different observation."
+    )
+
+
+def test_should_run_four(test_pipeline):
+    obs = get_obs("8007")
+    four = test_pipeline.tasks["four"]
+
+    assert test_pipeline.inner_function.call_count == 0
+    assert four.should_run(obs), "Task four should run initially"
+
+    # we run task four dependencies by hand so we don't get errors in dependency resolution
+    test_pipeline.tasks["one"](obs)
+    test_pipeline.tasks["two"](obs)
+    test_pipeline.tasks["three"](obs)
+
+    assert four.should_run(obs), "Task four should run initially"
+    four(obs)
+    assert not four.should_run(obs), "Task four should not run again"
+    four.invalidate_result(obs)
+    assert four.should_run(obs), "Task four should run again after cache clear"
+    four(obs)
+    obs.file_path("test/three_2.txt").unlink(missing_ok=True)
+    assert not four.should_run(obs), (
+        "Task four should run again if three_2.txt is missing (missing inputs do not invalidate the result)"
+    )
+    four(obs)
+    assert not four.should_run(obs), "Task four should not run again (2)"
+
+
+def test_sequence_one(test_pipeline, test_obs):
+    # test that a task should run once and only once
+    test_pipeline.run_task(test_obs, "one")
+    assert _call_args_list(test_pipeline.inner_function) == [("one", "8007")], (
+        "Task one should have run"
+    )
+    test_pipeline.run_task(test_obs, "one")
+    assert _call_args_list(test_pipeline.inner_function) == [("one", "8007")], (
+        "Task one should run only once"
+    )
+
+
+def test_sequence_two(test_pipeline, test_obs):
+    # task two depends on task one, so both should run
+    test_pipeline.run_task(test_obs, "two")
+    assert _call_args_list(test_pipeline.inner_function) == [
+        ("one", "8007"),
+        ("two", "8007"),
+    ], "Task one and two should be run"
+
+
+def test_sequence_five(test_pipeline, test_obs):
+    # task five does not depend on any other task (this test a disconnected dependency graph)
+    test_pipeline.run_task(test_obs, "five")
+    assert _call_args_list(test_pipeline.inner_function) == [("five", "8007")], (
+        "Task five should run"
+    )
+
+
+def test_sequence_four(test_pipeline, test_obs):
+    # checking a diamon dependency chain
+    test_obs = get_obs("8007")
+    test_pipeline.run_task(test_obs, "four")
+    # the task dependency graph is a diamon, tasks two and three are in the same level
+    # so they can be run in any order
+    possible_stacks = [
+        [("one", "8007"), ("two", "8007"), ("three", "8007"), ("four", "8007")],
+        [("one", "8007"), ("three", "8007"), ("two", "8007"), ("four", "8007")],
+    ]
+    assert _call_args_list(test_pipeline.inner_function) in possible_stacks, (
+        "Task one, two, three and four should be run"
+    )
+
+
+def test_invalidate_result_output_1(test_pipeline, test_obs):
+    # This tests checks that removing an output file invalidates the result.
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # removing an output file invalidates the result, and the task (and nothing else) should be run
+    test_obs.file_path(f"test/four_{test_obs.obsid}_1.txt").unlink(missing_ok=True)
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [("four", "8007")], (
+        "Task four should be run again due to missing file four_{obsid}_1.txt"
+    )
+
+
+def test_invalidate_result_output_2(test_pipeline, test_obs):
+    # this test checks that a missing output file that was not created when the task ran
+    # does not invalidate the result
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # removing an output file that was not created does not invalidate the result
+    test_obs.file_path(f"test/four_{test_obs.obsid}_2.txt").unlink(missing_ok=True)
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [], (
+        "Task four should not run again due to missing file four_{obsid}_2.txt"
+    )
+
+
+def test_invalidate_result(test_pipeline, test_obs):
+    # This test checks the behaviour when a task is explicitly invalidated.
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # explicitly invalidating the result, the task (and nothing else) should be run
+    test_pipeline.tasks["four"].invalidate_result(test_obs)
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [("four", "8007")], (
+        "Task four should be run again due to invalid cache"
+    )
+
+
+def test_invalidate_result_input(test_pipeline, test_obs):
+    # This test checks that removing the INPUT of a task does not invalidate the result.
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # removing an input file does not invalidate the result
+    test_obs.file_path("test/three_2.txt").unlink(missing_ok=True)
+    test_pipeline.run_task(test_obs, "four")
+    assert test_pipeline.inner_function.call_count == 0, (
+        "Task four should not be run again because missing inputs do not invalidate the result"
+    )
+
+
+def test_invalidate_result_dependency_input(test_pipeline, test_obs):
+    # This test invalidates a task (four), which STRICTLY depends on the output of another (three).
+    # That means that task three should run if the file is missing.
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # removing an output file invalidates the result,
+    test_obs.file_path(f"test/four_{test_obs.obsid}_1.txt").unlink(missing_ok=True)
+    # and removing an input from a dependency causes the dependency to be run as well
+    test_obs.file_path("test/three_2.txt").unlink(
+        missing_ok=True
+    )  # required by task four
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [
+        ("three", "8007"),
+        ("four", "8007"),
+    ], (
+        f"Task three and four should be run again due to missing files three_2.txt and four_{test_obs.obsid}_1.txt"
+    )
+
+
+def test_invalidate_result_dependency_input_2(test_pipeline, test_obs):
+    # This test invalidates a task (six), which OPTIONALLY depends on the output of another (three).
+    # That means that task three should run if the file is missing.
+    test_pipeline.run_task(test_obs, "six")
+    test_pipeline.inner_function.reset_mock()
+
+    # explicitly invalidating the result of task six
+    test_pipeline.tasks["six"].invalidate_result(test_obs)
+    # and removing an optional input from a dependency causes the dependency to be run as well
+    test_obs.file_path("test/three_2.txt").unlink(
+        missing_ok=True
+    )  # optional input for task six
+    test_pipeline.run_task(test_obs, "six")
+    assert _call_args_list(test_pipeline.inner_function) == [
+        ("three", "8007"),
+        ("six", "8007"),
+    ], (
+        f"Task three and four should be run again due to missing files three_2.txt and four_{test_obs.obsid}_1.txt"
+    )
+
+
+def test_invalidate_result_dependency_input_3(test_pipeline, test_obs):
+    # This test invalidates task six, which OPTIONALLY depends on one output of task eight.
+    # That means that task eight should run if the file is missing, unless we know that task eight
+    # has run before and the file was not produced.
+    test_pipeline.run_task(test_obs, "six")
+    assert ("eight", "8007") in _call_args_list(test_pipeline.inner_function), (
+        "Task eight should have run initially because it produces an optional input for task six"
+    )
+    test_pipeline.inner_function.reset_mock()
+
+    # explicitly invalidating the result of task six
+    test_pipeline.tasks["six"].invalidate_result(test_obs)
+    # and removing a non-existent optional input from a dependency
+    # does not cause the dependency to be run
+    test_obs.file_path("test/eight.txt").unlink(missing_ok=True)
+    test_pipeline.run_task(test_obs, "six")
+    assert _call_args_list(test_pipeline.inner_function) == [("six", "8007")], (
+        f"Task three and four should be run again due to missing files three_2.txt and four_{test_obs.obsid}_1.txt"
+    )
+
+
+def test_invalidate_dependency(test_pipeline, test_obs):
+    # this test invalidates one task (three), which has the side-effect of invalidating a dependent
+    # task (four). It then runs both tasks separately
+
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # invalidating the result of task three should cause four to be run again,
+    # even though task four's cache is still "valid"
+    test_pipeline.tasks["three"].invalidate_result(test_obs)
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [
+        ("three", "8007"),
+        ("four", "8007"),
+    ], (
+        "Task three and four should be run again because the cache of task three was cleared"
+    )
+
+
+def test_invalidate_dependency_file(test_pipeline, test_obs):
+    # this test invalidates one task (four) by removing its output,
+    # it also removes an output of task three, but task four does not depend on it
+    # so task three should not be run again
+
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # Task four depends on three, but only through the output file three_2.txt,
+    # removing the other output of task three should not cause task three to be run when re-running four
+    test_obs.file_path("test/three_1.txt").unlink(missing_ok=True)
+    test_obs.file_path(f"test/four_{test_obs.obsid}_1.txt").unlink(missing_ok=True)
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [("four", "8007")], (
+        f"Task four should be run again because missing four_{test_obs.obsid}_1.txt and task three should not run even though three_1.txt is missing"
+    )
+
+
+def test_invalidate_dependency_two_steps(test_pipeline, test_obs):
+    # this test invalidates one task (three), which has the side-effect of invalidating a dependent
+    # task (four). It then runs both tasks separately
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # invalidate cache in the middle, only run the intermediate task, then run the last task
+    test_pipeline.tasks["three"].invalidate_result(test_obs)
+    test_pipeline.run_task(test_obs, "three")  # three is re-run here, four is not
+    assert _call_args_list(test_pipeline.inner_function) == [("three", "8007")], (
+        "Task three should run again because its cache was cleared"
+    )
+
+    # four should run here even though its result has not been explicitly invalidated
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [
+        ("three", "8007"),
+        ("four", "8007"),
+    ], "Task four should run again because the cache of task three was cleared"
+
+
+def test_invalidate_archive(test_pipeline, test_obs):
+    # running "four" to begin with
+    test_pipeline.run_task(test_obs, "four")
+    test_pipeline.inner_function.reset_mock()
+
+    # archiving all but task three
+    test_obs.archive("test/one*", "test/two*", "test/four*", "cache/*")
+
+    # running "four" again should not run the task, because the result is still valid
+    test_pipeline.run_task(test_obs, "four")
+    assert _call_args_list(test_pipeline.inner_function) == [], "Task already ran"
+
+    # create an observation with a different work directory but the same archive directory
+    workdir = tempfile.TemporaryDirectory()
+    obs_2 = observation.Observation(
+        test_obs.obsid,
+        workdir=workdir.name,
+        archive_dir=test_obs.archive_dir.parent.parent,
+    )
+
+    os.chmod(obs_2.archive_dir, 0o500)  # ensure the archive is NOT writable
+    with pytest.raises(PermissionError):
+        open(obs_2.archive_dir / "fail.txt", "w").close()
+
+    # task "four" should not run on the new observation,
+    # because the result is still valid in the archive directory
+    test_pipeline.run_task(obs_2, "four")
+    stack = _call_args_list(test_pipeline.inner_function)
+    assert stack == [], "Task already ran (archived)"
+
+    test_pipeline.tasks["four"].invalidate_result(obs_2)
+
+    # after invalidating the result, the task should run again
+    # and because we did not archive task three, it should run as well
+    test_pipeline.run_task(obs_2, "four")
+    stack = _call_args_list(test_pipeline.inner_function)
+    assert stack == [("three", "8007"), ("four", "8007")], (
+        "Tasks three and four should run again"
+    )
+
+
+def test_task_return_value(test_pipeline):
+    # check the possible return values: None, and tuples of size 1 and 2
+
+    @test_pipeline.task()
+    def none(obs, inputs, outputs):
+        pass
+
+    @test_pipeline.task()
+    def one(obs, inputs, outputs):
+        return task.ReturnCode.OK
+
+    @test_pipeline.task()
+    def two(obs, inputs, outputs):
+        return task.ReturnCode.SKIP, "skipped"
+
+    obs = get_obs("8007")
+
+    rv = none(obs)
+    assert isinstance(rv, task.ReturnValue), (
+        "Return value should be a ReturnValue object"
+    )
+    assert rv
+
+    rv = two(obs)
+    assert isinstance(rv, task.ReturnValue), (
+        "Return value should be a ReturnValue object"
+    )
+    assert not rv
+    assert rv.return_code == task.ReturnCode.SKIP
+    assert rv.msg == "skipped"
+
+    rv = one(obs)
+    assert isinstance(rv, task.ReturnValue), (
+        "Return value should be a ReturnValue object"
+    )
+    assert rv
+    assert rv.return_code == task.ReturnCode.OK
+    assert rv.msg == ""
+
+
+def test_download(test_pipeline):
+    # check that some files are downloaded from the archive
+    @test_pipeline.task(
+        name="dnld",
+        download=["evt2", "fov"],
+    )
+    def dnls(obs, inputs, outputs):
+        pass
+
+    obs = get_obs("8007")
+    dnls(obs)
+    assert len(list(obs.workdir.glob("*/*evt2*"))) == 1, "missing event files"
+    assert len(list(obs.workdir.glob("*/*fov*"))) == 1, "missing FOV files"
+
+
+def test_repeated_task_name(test_pipeline):
+    # check that defining a task with the same name raises an error
+    with pytest.raises(ValueError):
+
+        @test_pipeline.task(
+            name="five",
+        )
+        def five(obs, inputs, outputs):
+            pass
+
+
+def test_dependencies():
+    # Test the "dependencies" decorator with a simple task
+
+    TASKS = task.TaskManager()
+    STACK = []
+    TMPDIR = tempfile.TemporaryDirectory()
+
+    @TASKS.task(
+        name="do",
+        outputs={"do": "do_nothing.json"},
+    )
+    def do(obs, inputs=None, outputs=None):
+        STACK.append(("do", obs.obsid))
+        with open(outputs["do"], "w") as f:
+            f.write("This is a placeholder task that does nothing.")
+
+    class Data:
+        def __init__(self):
+            self.storage = stored_result.Storage(workdir=TMPDIR.name)
+            self.obsid = "1"
+
+        @property
+        def workdir(self):
+            """
+            Returns the work directory for the current observation.
+            """
+            return self.storage.workdir
+
+        def file_path(self, *args, **kwargs):
+            """
+            Returns the file path for the given arguments.
+            """
+            return self.storage.path(*args, **kwargs)
+
+        def file_glob(self, *args, **kwargs):
+            """
+            Returns the file path for the given arguments.
+            """
+            return self.storage.glob(*args, **kwargs)
+
+        def download(self, *args, **kwargs):
+            """
+            Downloads the file for the given arguments.
+            """
+
+        @TASKS.dependencies(required_files={"do": "do_{name}.json"})
+        def method(self, name="nothing", apply_filter=True):
+            return {"name": name, "apply_filter": apply_filter}
+
+    data = Data()
+    # check that the method runs and returns the expected result
+    assert data.method() == {"name": "nothing", "apply_filter": True}
+    # check that the result is the same with the default argument
+    assert data.method(name="nothing") == {"name": "nothing", "apply_filter": True}
+    # check that the "do" task ran once and only once
+    assert STACK == [("do", "1")], "Task do should be run exactly once"
+
+    # the method does not accept positional arguments
+    with pytest.raises(RuntimeError, match="positional arguments"):
+        data.method("nothing")
+
+    # test that requiring a file that is not produced by any tasks raises an exception
+    # (no task produces do_bla.json)
+    with pytest.raises(FileNotFoundError, match="do_bla.json"):
+        data.method(name="bla")  # fails, file not found
+    assert STACK == [("do", "1")], "Task do should be run exactly once"


### PR DESCRIPTION
## Description

This PR includes improvements to make downstream processing (after astromon) faster.

The largest change is the addition of:
- a `task` decorator which keeps tracks between function dependencies. This is intended for CIAO processing steps which require some input files and produce output files. When a task is run, its dependencies will run.
- a `dependencies` decorator which can be used in functions to make sure some tasks are run before calling the function
- a `stored_result` to cache (intermediate) function return values.
- a `Storage` class to better handle the (temporary) working directory and the archive directory (in SKA/data).

Other smaller changes include:
- Skip downloading files that we know will not be there (otherwise there is 0.5 sec wasted checking for each file that is not there)
- do not download from Chandra archive until the file is about to be used
- do not check if CIAO works at every instantiation of the Observation class
- delay calls of `get_obspar` as they might download from the archive (new is_hrc and is_acis methods)

Also some changes that are not improvements in the sense above:
- replace uses of pyyaks with ska_helpers
- fixed a crash that happened in a corner case

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

No interface impact.

The data stored by this module will change a bit. That should cause no disruption but it can make the processing slower the first time it is called on an observation. One can replace the older observation data with the one produced with this branch by replacing the contents of `/proj/sot/ska/data/astromon/archive` with the contents of `/data/aca/periscope_drift/data`

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [x] Linux
- [ ] Windows

```
(periscope-drift) jgonzale astromon $ git rev-parse HEAD
653c83bc4ba066b75af09b80ef98efd6d47efd09
(periscope-drift) jgonzale astromon $ pytest astromon
======================================================================= test session starts =======================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, dash-3.0.3, timeout-2.3.1
collected 46 items                                                                                                                                                

astromon/tests/test_cross_match.py ...                                                                                                                      [  6%]
astromon/tests/test_db.py ....                                                                                                                              [ 15%]
astromon/tests/test_stored_result.py ................                                                                                                       [ 50%]
astromon/tests/test_task.py .......................                                                                                                         [100%]

======================================================================= 46 passed in 48.03s =======================================================================

```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

This PR should not introduce changes, because the algorithm should not have changed (much). I made a notebook checking the output over about 1.5 year: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/astromon/pr-36/astromon_pr-36-verification.html
