### PR TITLE
Update for numpy > 2 (isin) and update test configuration

### DIFF
--- a/astromon/__init__.py
+++ b/astromon/__init__.py
@@ -8,3 +8,12 @@ from .db import get_cross_matches
 logger = ska_helpers.logging.basic_logger(
     "astromon", level="CRITICAL", format="%(asctime)s %(funcName)-25s: %(message)s"
 )
+
+
+def test(*args, **kwargs):
+    """
+    Run py.test unit tests.
+    """
+    import testr
+
+    return testr.test(*args, **kwargs)

--- a/astromon/cross_match.py
+++ b/astromon/cross_match.py
@@ -478,7 +478,7 @@ def filter_matches(  # noqa: PLR0912
         ok &= np.abs(sim_z_offset) <= sim_z
 
     if exclude_categories:
-        ok &= ~np.in1d(matches["category"], exclude_categories)
+        ok &= ~np.isin(matches["category"], exclude_categories)
 
     for key, val in kwargs.items():
         if isinstance(val, list):
@@ -712,7 +712,7 @@ def simple_cross_match(
         (astromon_xray_src["snr"] > snr)
         & (astromon_xray_src["near_neighbor_dist"] > near_neighbor_dist)
     ]
-    astromon_cat_src = astromon_cat_src[np.in1d(astromon_cat_src["catalog"], catalogs)]
+    astromon_cat_src = astromon_cat_src[np.isin(astromon_cat_src["catalog"], catalogs)]
 
     # I can rename and drop these to match the standard in astromon.db because I just made copies
     astromon_cat_src.rename_columns(

--- a/astromon/db.py
+++ b/astromon/db.py
@@ -317,7 +317,7 @@ def save(table_name, data, dbfile, ignore_obsid=False):
                 # remove rows for these obsids
                 obsids = np.unique(data["obsid"])
                 data_out = node[:].astype(dtype)
-                data_out = data_out[~np.in1d(data_out["obsid"], obsids)]
+                data_out = data_out[~np.isin(data_out["obsid"], obsids)]
                 # append current data
                 data = np.concatenate((data_out, data))
             h5.remove_node(node)
@@ -343,7 +343,7 @@ def remove_regions(regions, dbfile=None):
     """
     with connect(dbfile, mode="r+") as h5:
         all_regions = get_table("astromon_regions", h5)
-        sel = ~np.in1d(all_regions["region_id"], regions)
+        sel = ~np.isin(all_regions["region_id"], regions)
         all_regions = all_regions[sel]
 
         # We just removed some regions. In the process, maybe all rows for a given obsid were
@@ -505,11 +505,11 @@ def sync_regions(from_file, to_file, remove=False):
     for i1, i2 in zip(up_to_idx, up_from_idx, strict=True):
         to_regions[i1] = from_regions[i2]
     # remove records that are in to_file but not in from_file
-    missing = ~np.in1d(to_regions["region_id_str"], from_regions["region_id_str"])
+    missing = ~np.isin(to_regions["region_id_str"], from_regions["region_id_str"])
     if remove and np.any(missing):
         to_regions = to_regions[~missing]
     # add records that are only in from_file
-    new = ~np.in1d(from_regions["region_id_str"], to_regions["region_id_str"])
+    new = ~np.isin(from_regions["region_id_str"], to_regions["region_id_str"])
     if np.any(new):
         # make sure that region_id is not repeated
         # if there are repeated region_ids, assign new ones continuing from last_region_id in meta

--- a/astromon/scripts/get_cat_obs_data.py
+++ b/astromon/scripts/get_cat_obs_data.py
@@ -347,7 +347,7 @@ def main():  # noqa: PLR0912, PLR0915
         obsids = np.array(obsids, dtype=int)
         try:
             astromon_obs = db.get_table("astromon_obs", dbfile=db_file)
-            exceptions = np.in1d(obsids, astromon_obs["obsid"])
+            exceptions = np.isin(obsids, astromon_obs["obsid"])
             n_exceptions = np.sum(exceptions)
             if n_exceptions:
                 exceptions_str = str(obsids[exceptions])[1:-1]

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "astromon.scripts",
         "astromon.scripts.calalign",
         "astromon.scripts.calalign.check",
+        "astromon.tests",
         "astromon.web",
     ],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     package_data={
         "astromon": ["sql/x-corr/*.sql", "sql/tables/*.sql"],
         "astromon.web": ["templates/*"],
+        "astromon.tests": ["data/*"],
     },
     data_files=data_files,
     license=(


### PR DESCRIPTION
## Description

Update for numpy > 2 (replace in1d with isin to stop deprecation warnings) and add test init file for pytest test discovery

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Theoretically, with the new `__init__.py` file, tests will work without needing to add the repo to PYTHONPATH.  Adding the tests to setup.py should allow the tests to run from the installation.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
jeanconn-kady> pytest
======================================================= test session starts ========================================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 50 items                                                                                                                 

astromon/tests/test_cross_match.py ...                                                                                       [  6%]
astromon/tests/test_db.py ........                                                                                           [ 22%]
astromon/tests/test_stored_result.py ................                                                                        [ 54%]
astromon/tests/test_task.py .......................                                                                          [100%]

========================================================= warnings summary =========================================================
astromon/astromon/tests/test_task.py: 18 warnings
  /proj/sot/ska3/test/lib/python3.13/pty.py:95: DeprecationWarning: This process (pid=2020069) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 50 passed, 18 warnings in 50.49s =================================================
jeanconn-kady> git rev-parse HEAD
a63dde8db45ffff243f36a5f17afb904e990e8d8
jeanconn-kady> conda list ska3-flight
# packages in environment at /proj/sot/ska3/test:
#
# Name                     Version          Build            Channel
ska3-flight                2026.1rc4        0                https://icxc.cfa.harvard.edu/aspect/ska3-conda/test
```

Independent check of unit tests by Javier
- [x] Linux:
```
(ska3-flight-2026.1rc4) jgonzale astromon $ git rev-parse HEAD
65a5b6b7eae4d992359eb468b36506acc70471bb
(ska3-flight-2026.1rc4) jgonzale astromon $ pytest astromon
===================================================================== test session starts =====================================================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: timeout-2.4.0, anyio-4.12.1
collected 50 items                                                                                                                                            

astromon/tests/test_cross_match.py ...                                                                                                                  [  6%]
astromon/tests/test_db.py ........                                                                                                                      [ 22%]
astromon/tests/test_stored_result.py ................                                                                                                   [ 54%]
astromon/tests/test_task.py .......................                                                                                                     [100%]

===================================================================== 50 passed in 50.47s =====================================================================

```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
