### PR TITLE
Fix small processing issues

### DIFF
--- a/astromon/cross_match.py
+++ b/astromon/cross_match.py
@@ -12,6 +12,7 @@ from astropy import units as u
 from astroquery.vizier import Vizier
 from cxotime import CxoTime
 from Ska.DBI import DBI
+from ska_helpers.retry import retry
 
 import astromon
 from astromon import db, observation, utils
@@ -21,7 +22,17 @@ logger = logging.getLogger("astromon")
 
 SIM_Z = {"ACIS-I": -233.587, "ACIS-S": -190.143, "HRC-I": 126.983, "HRC-S": 250.466}
 
+# Vizier queries occasionally fail with a transient connection reset unrelated to the query
+# itself.
+retry_on_connection_error = retry(
+    exceptions=(requests.exceptions.ConnectionError, requests.exceptions.Timeout),
+    tries=3,
+    delay=1,
+    backoff=2,
+)
 
+
+@retry_on_connection_error
 def _get_vizier(source, ra, dec, time, radius):
     """
     This fetches the vizier url, but it doesn't parse the result.
@@ -68,6 +79,11 @@ CROSS_MATCH_DTYPE = np.dtype(
 )
 
 
+@retry_on_connection_error
+def _query_vizier_region(vizier, pos, radius, cat_identifier):
+    return vizier.query_region(pos, radius=radius, catalog=cat_identifier, cache=False)
+
+
 def get_vizier(
     pos,
     catalog,
@@ -86,9 +102,7 @@ def get_vizier(
                 f"_DE(J2000,{pos.obstime.frac_year:8.3f})",
             ],
         )
-        vizier_result = vizier.query_region(
-            pos, radius=radius, catalog=cat_identifier, cache=False
-        )
+        vizier_result = _query_vizier_region(vizier, pos, radius, cat_identifier)
         vizier_result = list(vizier_result)
     else:
         vizier_result = [

--- a/astromon/cross_match.py
+++ b/astromon/cross_match.py
@@ -187,7 +187,7 @@ VIZIER_CATALOGS = {
     "2MASS": {
         "catalog": "2MASS",
         "cat_identifier": "II/246/out",
-        "name_cols": ["_2MASS"],
+        "name_cols": ["2MASS"],
         "columns": {"ra": "_RAJ2000", "dec": "_DEJ2000", "mag": "Kmag"},
     },
     "SDSS": {

--- a/astromon/cross_match.py
+++ b/astromon/cross_match.py
@@ -174,7 +174,7 @@ VIZIER_CATALOGS = {
         "columns": {
             "ra": "_RAJ2000",
             "dec": "_DEJ2000",
-            "mag": "Vmag",
+            "mag": "Hpmag",
         },
     },
     # http://vizier.u-strasbg.fr/viz-bin/VizieR?-source=I/322
@@ -205,7 +205,7 @@ VIZIER_CATALOGS = {
         "catalog": "Gaia2",
         "cat_identifier": "I/345/gaia2",
         "name_cols": ["Source"],
-        "columns": {"ra": "_RA_ICRS", "dec": "_DE_ICRS", "mag": "Gmag"},
+        "columns": {"ra": "_RAJ2000", "dec": "_DEJ2000", "mag": "Gmag"},
     },
 }
 

--- a/astromon/cross_match.py
+++ b/astromon/cross_match.py
@@ -139,8 +139,8 @@ VIZIER_CATALOGS = {
         "cat_identifier": "I/259/tyc2",
         "name_cols": ["TYC1", "TYC2", "TYC3"],
         "columns": {
-            "ra": "_RAJ2000_{time.frac_year:.3f}",
-            "dec": "_DEJ2000_{time.frac_year:.3f}",
+            "ra": "_RAJ2000/{time.frac_year:.3f}",
+            "dec": "_DEJ2000/{time.frac_year:.3f}",
             "mag": "VTmag",
         },
     },
@@ -195,8 +195,8 @@ VIZIER_CATALOGS = {
         "cat_identifier": "II/294",
         "name_cols": ["SDSS"],
         "columns": {
-            "ra": "_RAJ2000_{time.frac_year:.3f}",
-            "dec": "_DEJ2000_{time.frac_year:.3f}",
+            "ra": "_RAJ2000/{time.frac_year:.3f}",
+            "dec": "_DEJ2000/{time.frac_year:.3f}",
             "mag": "rmag",
         },
     },

--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -1500,8 +1500,7 @@ def filter_events(obs, inputs, outputs):
     # possible parameter:
     radius = 180  # radius in arcsec
 
-    # I'm using a fixed pixel size of 0.5 arcsec, but this might need fixing
-    pixel = 1 if obs.is_hrc else 0.5
+    pixel = 0.13180 if obs.is_hrc else 0.5
 
     evt = inputs["events"][0]
     evt2 = outputs["events"]
@@ -1556,9 +1555,7 @@ def filter_sources(obs, inputs, outputs):
     radius = 180  # radius in arcsec
     psfratio = 1
 
-    # I don't think the following should be a parameter
-    # I'm using a fixed pixel size of 0.5 arcsec, but this might need fixing
-    pixel = 1 if obs.is_hrc else 0.5
+    pixel = 0.13180 if obs.is_hrc else 0.5
 
     evt = inputs["events"]
 

--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -1435,13 +1435,15 @@ def celldetect(obs, inputs, outputs):
     # possible parameter:
     snr = 3
 
+    # Note that the hrc pixel size of 0.13180 results in a 2733x2733
+    # minimum image that suggests just using the 4096 window.
     obs.ciao(
         "celldetect",
         inputs["image_file"],
         outputs["src"],
         psffile=inputs["psf_file"],  # either this or set fixedcell=
         thresh=snr,
-        maxlogicalwindow=2048,
+        maxlogicalwindow=4096,
         clobber="yes",
         logging_tag=str(obs),
     )

--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -194,7 +194,7 @@ class Observation:
             self.archive_regex = archive_regex
         self._source = source
         logger.info(f"{self} starting. Context: {self.workdir}")
-        self._rebin = False
+        self._rebin = True
         self.ciao_ = None
         # ciao is initialized only if needed, but we make this check at the very beginning
         # so the user gets a warning at the top if calling CIAO will likely fail

--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -1435,8 +1435,8 @@ def celldetect(obs, inputs, outputs):
     # possible parameter:
     snr = 3
 
-    # Note that the hrc pixel size of 0.13180 results in a 2733x2733
-    # minimum image that suggests just using the 4096 window.
+    # Note that the maxlogicalwindow needs to be bigger than whatever the
+    # binned filtered image is.
     obs.ciao(
         "celldetect",
         inputs["image_file"],

--- a/astromon/observation.py
+++ b/astromon/observation.py
@@ -1443,7 +1443,7 @@ def celldetect(obs, inputs, outputs):
         outputs["src"],
         psffile=inputs["psf_file"],  # either this or set fixedcell=
         thresh=snr,
-        maxlogicalwindow=4096,
+        maxlogicalwindow=2048,
         clobber="yes",
         logging_tag=str(obs),
     )

--- a/astromon/tests/test_cross_match.py
+++ b/astromon/tests/test_cross_match.py
@@ -1,11 +1,29 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
+import requests
+from astropy import units as u
 from astropy.table import Table
+from cxotime import CxoTime
+from ska_helpers.retry import retry
+from testr.test_helper import has_internet
 
 from astromon import cross_match, db
 
 DATA_DIR = Path(__file__).parent / "data"
+
+HAS_INTERNET = has_internet()
+
+# Vizier queries occasionally hit a transient connection reset with no indication of an actual
+# problem with the query itself (observed as requests.exceptions.ConnectionError). Retry those
+# rather than failing the test outright.
+retry_on_connection_error = retry(
+    exceptions=(requests.exceptions.ConnectionError, requests.exceptions.Timeout),
+    tries=3,
+    delay=1,
+    backoff=2,
+)
 
 
 def _get_table(name, *args, **kawargs):
@@ -52,3 +70,164 @@ def test_custom_args(monkeypatch):
         dr=3.0,
     )
     assert len(matches) == 5
+
+
+# Real, known cross-matches to check against live Vizier queries, one per catalog in
+# cross_match.VIZIER_CATALOGS. Each entry in cross_match.VIZIER_CATALOGS maps 'ra'/'dec'/'mag'
+# to specific column names in the raw astroquery/Vizier response, and those names are neither
+# obvious nor guaranteed to stay the same: astroquery > 0.4.8 changed the separator used in
+# proper-motion-corrected column names (e.g. '_RAJ2000_2020.500' -> '_RAJ2000/2020.500') and
+# renamed the 2MASS name column ('_2MASS' -> '2MASS'). A wrong column name for 'ra'/'dec'/'mag'
+# does not raise an exception: cross_match.get_vizier silently fills the column with masked
+# values instead (see astromon/cross_match.py), so a regression here is easy to miss without a
+# test that checks actual values.
+#
+# The Tycho2/2MASS/USNO-B1.0/UCAC4 entries below are the real cross-matches for OBSID 13276
+# recorded in astromon/tests/data/astromon_cat_src.ecsv. HIP/HIP2 use Sirius, and ICRS uses
+# 3C 273 (a defining ICRF source), since those catalogs have no match in that field.
+#
+# 'search_ra'/'search_dec' are passed to the query. 'ra'/'dec' are the expected result: these
+# differ for HIP/HIP2 because Sirius has a large enough proper motion (~1.3 arcsec/year) that its
+# J2000 catalog position (the search center) and its position propagated to VIZIER_QUERY_TIME
+# (the expected 'ra'/'dec' column values) are about 17 arcsec apart.
+KNOWN_VIZIER_SOURCES = {
+    "Tycho2": {
+        "search_ra": 258.0868754233,
+        "search_dec": -38.4918276755,
+        "radius": 2 * u.arcsec,
+        "name": "7870-965-1",
+        "ra": 258.0868754233,
+        "dec": -38.4918276755,
+        "mag": 10.982,
+    },
+    "2MASS": {
+        "search_ra": 258.044673,
+        "search_dec": -38.507812,
+        "radius": 2 * u.arcsec,
+        "name": "17121072-3830281",
+        "ra": 258.044673,
+        "dec": -38.507812,
+        "mag": 13.087,
+    },
+    "USNO-B1.0": {
+        "search_ra": 258.120025,
+        "search_dec": -38.471181,
+        "radius": 2 * u.arcsec,
+        "name": "0515-0502275",
+        "ra": 258.120025,
+        "dec": -38.471181,
+        "mag": 15.13,
+    },
+    "UCAC4": {
+        "search_ra": 258.084256925,
+        "search_dec": -38.498867073,
+        "radius": 2 * u.arcsec,
+        "name": "258-115041",
+        "ra": 258.084256925,
+        "dec": -38.498867073,
+        "mag": 14.871,
+    },
+    "HIP": {
+        "search_ra": 101.28715533,
+        "search_dec": -16.71611586,
+        "radius": 25 * u.arcsec,
+        "name": "32349",
+        "ra": 101.2850787107,
+        "dec": -16.7205708639,
+        "mag": -1.44,
+    },
+    "HIP2": {
+        "search_ra": 101.28715533,
+        "search_dec": -16.71611586,
+        "radius": 25 * u.arcsec,
+        "name": "32349",
+        "ra": 101.2850787128,
+        "dec": -16.7205708058,
+        "mag": -1.0876,
+    },
+    "ICRS": {
+        "search_ra": 187.2779155448750,
+        "search_dec": 2.0523884103056,
+        "radius": 2 * u.arcsec,
+        "name": "J122906.6+020308",
+        "ra": 187.2779155448750,
+        "dec": 2.0523884103056,
+        "mag": None,  # ICRS has no magnitude column, mag is expected to stay masked
+    },
+    "SDSS": {
+        "search_ra": 184.99294600,
+        "search_dec": 14.99606200,
+        "radius": 2 * u.arcsec,
+        "name": "J121958.30+145945.8",
+        "ra": 184.99294600,
+        "dec": 14.99606200,
+        "mag": 25.920,
+    },
+    "Gaia2": {
+        "search_ra": 258.0868754233,
+        "search_dec": -38.4918276755,
+        "radius": 3 * u.arcsec,
+        "name": "5973148908477305600",
+        "ra": 258.0868421690529,
+        "dec": -38.4917874972768,
+        "mag": 10.3580,
+    },
+}
+
+VIZIER_QUERY_TIME = CxoTime("2013-02-11T07:39:09")
+
+
+@pytest.mark.skipif(not HAS_INTERNET, reason="Requires network access")
+@pytest.mark.parametrize("catalog", sorted(KNOWN_VIZIER_SOURCES))
+@retry_on_connection_error
+def test_vizier_catalog_columns(catalog):
+    expected = KNOWN_VIZIER_SOURCES[catalog]
+    result = cross_match._get(
+        catalog,
+        VIZIER_QUERY_TIME,
+        ra=expected["search_ra"],
+        dec=expected["search_dec"],
+        radius=expected["radius"],
+    )
+
+    assert len(result) == 1
+    assert result["name"][0] == expected["name"]
+    assert not np.ma.is_masked(result["ra"][0])
+    assert not np.ma.is_masked(result["dec"][0])
+    assert np.isclose(result["ra"][0], expected["ra"], atol=1e-4)
+    assert np.isclose(result["dec"][0], expected["dec"], atol=1e-4)
+
+    if expected["mag"] is None:
+        assert np.ma.is_masked(result["mag"][0])
+    else:
+        assert not np.ma.is_masked(result["mag"][0])
+        assert np.isclose(result["mag"][0], expected["mag"], atol=0.01)
+
+
+# test_vizier_catalog_columns above checks that cross_match._get() maps columns correctly, but
+# nothing exercises rough_match() itself -- the function the production pipeline actually calls
+# (see astromon/scripts/get_cat_obs_data.py) -- for any catalog. That matters most for HIP, HIP2
+# and Gaia2: the standard cross-matches in CROSS_MATCHES_ARGS use only ICRS/Tycho2, and the
+# default call to rough_match() in get_cat_obs_data.py uses rough_match's own default catalog
+# list, which also excludes HIP/HIP2/Gaia2. So a bug in how rough_match() itself handles a
+# catalog (as opposed to a wrong column name) would surface in production for ICRS/Tycho2/
+# USNO-B1.0/2MASS/SDSS, but never for HIP/HIP2/Gaia2. This exercises rough_match() end-to-end for
+# every catalog in VIZIER_CATALOGS.
+@pytest.mark.skipif(not HAS_INTERNET, reason="Requires network access")
+@pytest.mark.parametrize("catalog", sorted(KNOWN_VIZIER_SOURCES))
+@retry_on_connection_error
+def test_rough_match_known_source(catalog):
+    expected = KNOWN_VIZIER_SOURCES[catalog]
+    sources = Table(
+        {"id": [1], "ra": [expected["search_ra"]], "dec": [expected["search_dec"]]}
+    )
+
+    result = cross_match.rough_match(
+        sources, VIZIER_QUERY_TIME, radius=expected["radius"], catalogs=[catalog]
+    )
+
+    assert len(result) == 1
+    assert result["catalog"][0] == cross_match.VIZIER_CATALOGS[catalog]["catalog"]
+    assert result["name"][0] == expected["name"]
+    assert result["x_id"][0] == 1
+    assert result["separation"][0] < expected["radius"].to_value(u.arcsec)

--- a/astromon/tests/test_observation.py
+++ b/astromon/tests/test_observation.py
@@ -1,0 +1,59 @@
+import re
+from unittest.mock import Mock
+
+import pytest
+
+from astromon import observation
+
+# The real HRC plate scale, per the Chandra Proposers' Observatory Guide. filter_events and
+# filter_sources both filter events/sources in a circle around the optical axis, and need to
+# convert the filter radius from arcsec to detector pixels. Using the wrong scale here does not
+# raise an exception: it silently changes the filtered region size (see astromon/observation.py).
+HRC_ARCSEC_PER_PIXEL = 0.13180
+ACIS_ARCSEC_PER_PIXEL = 0.5
+
+CIRCLE_RE = re.compile(r"circle\([^,]+,[^,]+,([^)]+)\)")
+
+
+def _fake_obs(is_hrc):
+    obs = Mock()
+    obs.is_hrc = is_hrc
+    obs.ciao = Mock()
+    obs.ciao.pget = Mock(side_effect=["10.0", "-20.0", "4096.5", "4096.5"])
+    return obs
+
+
+def _dmcopy_circle_radius(ciao_mock):
+    (dmcopy_call,) = [c for c in ciao_mock.call_args_list if c.args[0] == "dmcopy"]
+    match = CIRCLE_RE.search(dmcopy_call.args[1])
+    return float(match.group(1))
+
+
+@pytest.mark.parametrize(
+    "is_hrc,arcsec_per_pixel",
+    [(True, HRC_ARCSEC_PER_PIXEL), (False, ACIS_ARCSEC_PER_PIXEL)],
+)
+def test_filter_events_pixel_scale(is_hrc, arcsec_per_pixel):
+    obs = _fake_obs(is_hrc)
+    inputs = {"events": ["evt2.fits"], "fov": ["fov1.fits"]}
+    outputs = {"events": "evt2_filtered.fits.gz"}
+
+    observation.filter_events.func(obs, inputs, outputs)
+
+    radius = 180  # matches the fixed radius in filter_events
+    assert _dmcopy_circle_radius(obs.ciao) == pytest.approx(radius / arcsec_per_pixel)
+
+
+@pytest.mark.parametrize(
+    "is_hrc,arcsec_per_pixel",
+    [(True, HRC_ARCSEC_PER_PIXEL), (False, ACIS_ARCSEC_PER_PIXEL)],
+)
+def test_filter_sources_pixel_scale(is_hrc, arcsec_per_pixel):
+    obs = _fake_obs(is_hrc)
+    inputs = {"events": "evt2_filtered.fits.gz", "src": "baseline.src"}
+    outputs = {"src": "filtered.src"}
+
+    observation.filter_sources.func(obs, inputs, outputs)
+
+    radius = 180  # matches the fixed radius in filter_sources
+    assert _dmcopy_circle_radius(obs.ciao) == pytest.approx(radius / arcsec_per_pixel)

--- a/astromon/tests/test_task.py
+++ b/astromon/tests/test_task.py
@@ -4,8 +4,14 @@ from pprint import pprint
 from unittest.mock import Mock
 
 import pytest
+from testr.test_helper import on_head_network
 
 from astromon import observation, stored_result, task
+
+ON_HEAD_NETWORK = on_head_network()
+NEEDS_HEAD_NETWORK = pytest.mark.skipif(
+    not ON_HEAD_NETWORK, reason="Requires HEAD network access (arc5gl)"
+)
 
 
 class MockTaskManager(task.TaskManager):
@@ -274,6 +280,7 @@ def test_should_run_four(test_pipeline):
     assert not four.should_run(obs), "Task four should not run again (2)"
 
 
+@NEEDS_HEAD_NETWORK
 def test_sequence_one(test_pipeline, test_obs):
     # test that a task should run once and only once
     test_pipeline.run_task(test_obs, "one")
@@ -286,6 +293,7 @@ def test_sequence_one(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_sequence_two(test_pipeline, test_obs):
     # task two depends on task one, so both should run
     test_pipeline.run_task(test_obs, "two")
@@ -295,6 +303,7 @@ def test_sequence_two(test_pipeline, test_obs):
     ], "Task one and two should be run"
 
 
+@NEEDS_HEAD_NETWORK
 def test_sequence_five(test_pipeline, test_obs):
     # task five does not depend on any other task (this test a disconnected dependency graph)
     test_pipeline.run_task(test_obs, "five")
@@ -303,6 +312,7 @@ def test_sequence_five(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_sequence_four(test_pipeline, test_obs):
     # checking a diamon dependency chain
     test_obs = get_obs("8007")
@@ -318,6 +328,7 @@ def test_sequence_four(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_result_output_1(test_pipeline, test_obs):
     # This tests checks that removing an output file invalidates the result.
     test_pipeline.run_task(test_obs, "four")
@@ -331,6 +342,7 @@ def test_invalidate_result_output_1(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_result_output_2(test_pipeline, test_obs):
     # this test checks that a missing output file that was not created when the task ran
     # does not invalidate the result
@@ -345,6 +357,7 @@ def test_invalidate_result_output_2(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_result(test_pipeline, test_obs):
     # This test checks the behaviour when a task is explicitly invalidated.
     test_pipeline.run_task(test_obs, "four")
@@ -358,6 +371,7 @@ def test_invalidate_result(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_result_input(test_pipeline, test_obs):
     # This test checks that removing the INPUT of a task does not invalidate the result.
     test_pipeline.run_task(test_obs, "four")
@@ -371,6 +385,7 @@ def test_invalidate_result_input(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_result_dependency_input(test_pipeline, test_obs):
     # This test invalidates a task (four), which STRICTLY depends on the output of another (three).
     # That means that task three should run if the file is missing.
@@ -392,6 +407,7 @@ def test_invalidate_result_dependency_input(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_result_dependency_input_2(test_pipeline, test_obs):
     # This test invalidates a task (six), which OPTIONALLY depends on the output of another (three).
     # That means that task three should run if the file is missing.
@@ -413,6 +429,7 @@ def test_invalidate_result_dependency_input_2(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_result_dependency_input_3(test_pipeline, test_obs):
     # This test invalidates task six, which OPTIONALLY depends on one output of task eight.
     # That means that task eight should run if the file is missing, unless we know that task eight
@@ -434,6 +451,7 @@ def test_invalidate_result_dependency_input_3(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_dependency(test_pipeline, test_obs):
     # this test invalidates one task (three), which has the side-effect of invalidating a dependent
     # task (four). It then runs both tasks separately
@@ -453,6 +471,7 @@ def test_invalidate_dependency(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_dependency_file(test_pipeline, test_obs):
     # this test invalidates one task (four) by removing its output,
     # it also removes an output of task three, but task four does not depend on it
@@ -471,6 +490,7 @@ def test_invalidate_dependency_file(test_pipeline, test_obs):
     )
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_dependency_two_steps(test_pipeline, test_obs):
     # this test invalidates one task (three), which has the side-effect of invalidating a dependent
     # task (four). It then runs both tasks separately
@@ -492,6 +512,7 @@ def test_invalidate_dependency_two_steps(test_pipeline, test_obs):
     ], "Task four should run again because the cache of task three was cleared"
 
 
+@NEEDS_HEAD_NETWORK
 def test_invalidate_archive(test_pipeline, test_obs):
     # running "four" to begin with
     test_pipeline.run_task(test_obs, "four")
@@ -573,6 +594,7 @@ def test_task_return_value(test_pipeline):
     assert rv.msg == ""
 
 
+@NEEDS_HEAD_NETWORK
 def test_download(test_pipeline):
     # check that some files are downloaded from the archive
     @test_pipeline.task(


### PR DESCRIPTION
## Description

Fix small processing issues

- hrc observations used a 1" pixel size in filter_events which was a mismatch with the effective pixel size of 0.13180".
- I changed the hrc observations to use the by-4 binning by default as it seemed to work fine and took a lot less time now that we have a bunch more pixels for hrc observations in the default 180" radius
- changes in astroquery > 0.4.8 resulted in changed column names in the vizier query returns - fixed
- added retry around all vizier queries
- unused catalogs had columns that were not consistent with what we are getting from vizier (unclear if that is from astroquery or just not tested)
- auto-created some new tests for the queries and rough-matching

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
